### PR TITLE
Fixed rides schema and migration

### DIFF
--- a/app/views/rides/show.json.jbuilder
+++ b/app/views/rides/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "rides/ride", ride: @ride

--- a/app/views/rides/show.json.jbuilder
+++ b/app/views/rides/show.json.jbuilder
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 json.partial! "rides/ride", ride: @ride

--- a/db/dont_use_fake_rides_data.csv
+++ b/db/dont_use_fake_rides_data.csv
@@ -1,0 +1,51 @@
+Day,Date,Driver,Van,Passenger Name & Phone,Passenger Address,Destination,Notes to Driver,Hours,Amount Paid,Ride Count,C,Notes/Date reserved,Confirmed with passenger,Driver email
+Tu,02/25/2025,Sarah P. pm,8,"Smith, Patricia (555-365-7042)",338 Main St.,631 Doctor's Office,"60 min, r/t",2.9,14.54,2,m,10/18:tel rqst (SP),10/18:tel,
+Th,02/05/2025,Sarah P. am,5,"Brown, Patricia (555-460-8334)",847 Birch Blvd.,591 Pharmacy,r/t,3.8,14.47,2,l,10/18:tel rqst (SP),10/18:tel,sent
+F,02/04/2025,Sarah P. am,8,"Brown, Robert (555-967-7320)",841 Maple Dr.,127 Community Center,60 min,1.1,26.0,1,l,10/18:tel rqst (SP),10/18:tel,
+Tu,02/23/2025,John D. pm,6,"Smith, Robert (555-632-2186)",815 Pine Rd.,933 Library,"r/t, 60 min",1.2,23.31,1,l,10/18:tel rqst (JD),10/18:tel,
+W,02/22/2025,John D. am,3,"Johnson, James (555-604-1582)",660 Main St.,876 Community Center,r/t,4.1,31.31,3,l,10/18:tel rqst (JD),10/18:tel,
+F,02/01/2025,Mike S. am,8,"Miller, Patricia (555-157-4132)",364 Maple Dr.,510 Grocery Store,60 min,4.1,49.68,1,m,10/18:tel rqst (MS),10/18:tel,sent
+Tu,02/27/2025,Mike S. am,8,"Smith, Robert (555-354-4934)",831 Birch Blvd.,421 Library,60 min,1.1,40.41,3,m,10/18:tel rqst (MS),10/18:tel,
+M,02/15/2025,Sarah P. pm,8,"Johnson, Patricia (555-988-6833)",315 Pine Rd.,707 Library,"60 min, Wheelchair, r/t",4.1,39.8,2,l,10/18:tel rqst (SP),10/18:tel,
+F,02/25/2025,John D. pm,8,"Brown, John (555-738-1704)",418 Birch Blvd.,304 Pharmacy,r/t,3.7,33.11,2,l,10/18:tel rqst (JD),10/18:tel,
+Th,02/06/2025,John D. am,7,"Miller, Robert (555-317-7619)",327 Main St.,420 Grocery Store,"r/t, $20, Wheelchair",2.4,48.81,3,m,10/18:tel rqst (JD),10/18:tel,sent
+M,02/03/2025,Emily R. pm,3,"Smith, Patricia (555-814-8138)",641 Birch Blvd.,536 Doctor's Office,"$20, r/t",2.6,43.43,1,l,10/18:tel rqst (ER),10/18:tel,sent
+F,02/26/2025,John D. am,8,"Brown, Patricia (555-475-9077)",230 Main St.,277 Senior Center,"Wheelchair, $20, 60 min",3.9,15.75,2,m,10/18:tel rqst (JD),10/18:tel,sent
+F,02/13/2025,James B. pm,5,"Davis, Robert (555-296-3313)",983 Main St.,657 Pharmacy,r/t,4.0,28.31,2,l,10/18:tel rqst (JB),10/18:tel,
+Th,02/06/2025,Mike S. am,8,"Davis, Mary (555-115-7538)",712 Pine Rd.,642 Library,"$20, Wheelchair, 60 min",4.0,19.11,1,l,10/18:tel rqst (MS),10/18:tel,sent
+Tu,02/04/2025,James B. pm,5,"Johnson, James (555-609-4211)",114 Maple Dr.,225 Pharmacy,"$20, r/t",1.2,35.46,3,l,10/18:tel rqst (JB),10/18:tel,sent
+Tu,02/27/2025,James B. pm,8,"Brown, Robert (555-741-7017)",359 Main St.,556 Community Center,$20,4.7,39.23,2,l,10/18:tel rqst (JB),10/18:tel,sent
+M,02/24/2025,Emily R. am,6,"Brown, John (555-777-5068)",207 Maple Dr.,811 Library,60 min,2.6,28.55,1,m,10/18:tel rqst (ER),10/18:tel,sent
+W,03/02/2025,Mike S. am,7,"Johnson, Robert (555-657-2934)",512 Cedar Ln.,578 Library,"r/t, $20, 60 min",3.2,23.48,3,m,10/18:tel rqst (MS),10/18:tel,sent
+F,02/06/2025,Sarah P. am,5,"Brown, John (555-354-5516)",243 Cedar Ln.,434 Senior Center,r/t,1.8,34.53,3,l,10/18:tel rqst (SP),10/18:tel,
+W,02/04/2025,Emily R. pm,8,"Smith, James (555-628-8885)",445 Pine Rd.,205 Library,"Wheelchair, r/t, 60 min",5.0,46.15,2,l,10/18:tel rqst (ER),10/18:tel,
+Tu,02/12/2025,Emily R. am,6,"Smith, John (555-694-2317)",329 Cedar Ln.,540 Grocery Store,"60 min, Wheelchair, $20",3.6,36.5,3,l,10/18:tel rqst (ER),10/18:tel,
+Th,02/05/2025,Mike S. pm,7,"Brown, Mary (555-281-5990)",147 Maple Dr.,579 Grocery Store,$20,3.4,13.84,3,m,10/18:tel rqst (MS),10/18:tel,
+Th,02/16/2025,James B. pm,6,"Brown, Robert (555-136-1614)",559 Main St.,241 Library,"60 min, r/t, Wheelchair",2.1,19.06,3,m,10/18:tel rqst (JB),10/18:tel,
+Tu,02/16/2025,Sarah P. am,8,"Smith, John (555-776-5895)",640 Cedar Ln.,297 Community Center,"60 min, $20, r/t",3.3,38.84,1,m,10/18:tel rqst (SP),10/18:tel,
+M,02/04/2025,Emily R. am,5,"Davis, James (555-904-8440)",894 Pine Rd.,877 Community Center,"$20, Wheelchair, r/t",2.4,47.62,1,m,10/18:tel rqst (ER),10/18:tel,sent
+F,02/25/2025,James B. am,8,"Miller, Patricia (555-594-4991)",780 Pine Rd.,781 Senior Center,r/t,4.3,22.55,3,m,10/18:tel rqst (JB),10/18:tel,sent
+Tu,02/13/2025,Sarah P. am,6,"Miller, Patricia (555-217-5913)",558 Oak Ave.,216 Library,r/t,2.8,33.87,1,l,10/18:tel rqst (SP),10/18:tel,sent
+F,02/21/2025,James B. pm,6,"Davis, Patricia (555-108-7928)",626 Oak Ave.,349 Pharmacy,"60 min, $20",2.7,11.41,1,m,10/18:tel rqst (JB),10/18:tel,
+M,02/03/2025,John D. am,7,"Miller, Mary (555-583-6629)",163 Cedar Ln.,611 Senior Center,"60 min, r/t, $20",3.3,49.22,3,m,10/18:tel rqst (JD),10/18:tel,sent
+Th,02/07/2025,Mike S. pm,6,"Brown, John (555-271-3731)",857 Maple Dr.,554 Community Center,"60 min, r/t",1.9,42.15,2,l,10/18:tel rqst (MS),10/18:tel,sent
+M,02/25/2025,Mike S. pm,3,"Miller, Patricia (555-606-7875)",277 Main St.,780 Library,"r/t, Wheelchair, $20",1.8,30.42,1,l,10/18:tel rqst (MS),10/18:tel,
+F,02/12/2025,James B. pm,7,"Johnson, James (555-213-5729)",441 Main St.,667 Community Center,$20,4.9,12.34,3,l,10/18:tel rqst (JB),10/18:tel,
+Th,02/11/2025,Emily R. pm,7,"Davis, Patricia (555-550-7828)",510 Oak Ave.,399 Library,60 min,2.9,34.8,3,l,10/18:tel rqst (ER),10/18:tel,
+Tu,02/26/2025,Mike S. pm,5,"Johnson, John (555-614-3416)",432 Main St.,289 Community Center,"$20, Wheelchair, 60 min",1.9,25.72,2,l,10/18:tel rqst (MS),10/18:tel,
+Th,02/08/2025,James B. pm,5,"Miller, Robert (555-138-1186)",286 Pine Rd.,523 Grocery Store,"60 min, Wheelchair, $20",1.1,24.1,1,l,10/18:tel rqst (JB),10/18:tel,
+F,02/10/2025,Mike S. pm,8,"Johnson, John (555-214-5890)",344 Cedar Ln.,860 Grocery Store,"60 min, Wheelchair",1.8,31.93,3,l,10/18:tel rqst (MS),10/18:tel,sent
+Tu,02/12/2025,John D. am,5,"Johnson, Robert (555-192-9919)",143 Birch Blvd.,548 Doctor's Office,r/t,4.8,12.7,2,l,10/18:tel rqst (JD),10/18:tel,
+Th,03/02/2025,James B. am,6,"Johnson, James (555-241-9080)",401 Main St.,565 Library,"r/t, 60 min",2.8,22.48,2,m,10/18:tel rqst (JB),10/18:tel,
+Th,02/05/2025,John D. am,5,"Smith, James (555-340-2910)",377 Birch Blvd.,270 Doctor's Office,"60 min, $20, r/t",3.6,34.27,2,l,10/18:tel rqst (JD),10/18:tel,sent
+Tu,02/05/2025,Emily R. am,6,"Miller, Mary (555-428-3258)",322 Birch Blvd.,779 Doctor's Office,"Wheelchair, $20",2.1,46.18,3,l,10/18:tel rqst (ER),10/18:tel,
+Th,02/11/2025,Mike S. am,8,"Miller, Mary (555-688-9808)",117 Maple Dr.,270 Grocery Store,"60 min, $20, Wheelchair",5.0,19.42,2,m,10/18:tel rqst (MS),10/18:tel,sent
+M,02/26/2025,John D. am,5,"Brown, James (555-409-2123)",867 Main St.,737 Library,"60 min, $20, Wheelchair",2.8,29.15,3,m,10/18:tel rqst (JD),10/18:tel,
+M,02/06/2025,Mike S. am,5,"Smith, Mary (555-249-2737)",509 Oak Ave.,919 Library,Wheelchair,2.7,37.79,2,m,10/18:tel rqst (MS),10/18:tel,
+W,02/07/2025,James B. pm,3,"Brown, John (555-745-6340)",744 Cedar Ln.,304 Pharmacy,"$20, 60 min",2.0,22.13,1,l,10/18:tel rqst (JB),10/18:tel,
+Tu,02/26/2025,Mike S. am,3,"Johnson, Patricia (555-142-4925)",122 Birch Blvd.,953 Senior Center,"60 min, $20",1.9,37.25,2,l,10/18:tel rqst (MS),10/18:tel,sent
+F,02/12/2025,James B. am,8,"Miller, John (555-740-1426)",353 Oak Ave.,630 Grocery Store,"Wheelchair, $20",4.1,25.61,1,l,10/18:tel rqst (JB),10/18:tel,
+Th,03/01/2025,John D. pm,3,"Davis, Mary (555-978-6201)",252 Oak Ave.,756 Grocery Store,"r/t, $20",3.8,36.05,1,m,10/18:tel rqst (JD),10/18:tel,sent
+M,02/17/2025,James B. am,3,"Davis, Patricia (555-549-4607)",605 Pine Rd.,342 Library,"60 min, r/t",4.3,14.88,2,l,10/18:tel rqst (JB),10/18:tel,sent
+F,02/23/2025,Mike S. pm,5,"Johnson, James (555-775-6042)",144 Cedar Ln.,822 Grocery Store,$20,1.8,26.02,1,l,10/18:tel rqst (MS),10/18:tel,sent
+F,02/13/2025,Mike S. pm,3,"Smith, Patricia (555-619-7419)",904 Main St.,584 Pharmacy,"Wheelchair, 60 min",3.4,13.13,3,l,10/18:tel rqst (MS),10/18:tel,sent

--- a/db/fake_rides_data.csv
+++ b/db/fake_rides_data.csv
@@ -1,4 +1,4 @@
-Day,Date,Driver,Van,Passenger Name and Phone,Passenger Address,Destination,Notes to Driver,Driver Initials,Hours,Amount Paid,Ride Count,C,Notes/Date reserved,Confirmed w/passenger,Driver email
+Day,Date,Driver,Van,Passenger Name and Phone,Passenger Address,Destination,Notes to Driver,Driver Initials,Hours,Amount Paid,Ride Count,C,Notes/Date reserved,Confirmed with passenger,Driver email
 F,02/28/2025,Sarah P. am,6,"Brown, Patricia (555-475-3199)",664 Main St.,171 Doctor's Office,60 min,SP,2.5,10.86,3,m,10/18:tel rqst (SP),10/18:tel,
 F,02/28/2025,Mike S. pm,5,"Brown, Robert (555-311-7172)",604 Birch Blvd.,387 Library,"r/t, Wheelchair, 60 min",MS,4.0,32.16,2,m,10/18:tel rqst (MS),10/18:tel,
 M,02/24/2025,Mike S. pm,3,"Smith, James (555-548-2851)",837 Pine Rd.,223 Library,60 min,MS,3.4,27.17,3,m,10/18:tel rqst (MS),10/18:tel,

--- a/db/migrate/20250224022846_createrides.rb
+++ b/db/migrate/20250224022846_createrides.rb
@@ -1,22 +1,24 @@
 class Createrides < ActiveRecord::Migration[7.2]
   def change
     create_table :rides do |t|
-      t.string "day", null: false
-      t.date "date", null: false
-      t.text "driver"
-      t.integer "van"
-      t.text "passenger_name_and_phone"
-      t.text "passenger_address"
-      t.text "destination"
-      t.text "notes_to_driver"
-      t.string "driver_initials"
-      t.float "hours"
-      t.decimal "amount_paid", precision: 10, scale: 2
-      t.integer "ride_count"
-      t.string "c"
-      t.text "notes_date_reserved"
-      t.text "confirmed_with_passenger"
-      t.string "driver_email"
+      t.string :day, null: false
+      t.date :date, null: false
+      t.text :driver
+      t.integer :van
+      t.text :passenger_name_and_phone
+      t.text :passenger_address
+      t.text :destination
+      t.text :notes_to_driver
+      t.string :driver_initials
+      t.float :hours
+      t.decimal :amount_paid, precision: 10, scale: 2
+      t.integer :ride_count
+      t.string :c
+      t.text :notes_date_reserved
+      t.text :confirmed_with_passenger
+      t.string :driver_email
+
+      t.timestamps
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_06_220111) do
     t.text "notes_date_reserved"
     t.text "confirmed_with_passenger"
     t.string "driver_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "shifts", force: :cascade do |t|

--- a/lib/tasks/import_fake_data.rake
+++ b/lib/tasks/import_fake_data.rake
@@ -1,0 +1,54 @@
+require "csv"
+
+namespace :import do
+  desc "Import data from a CSV file into a specified model"
+  task :data, [:file_path, :model_name] => :environment do |task, args|
+    file_path = args[:file_path].present? ? Rails.root.join(args[:file_path]) : nil
+    model_name = args[:model_name]
+
+    if file_path.nil? || model_name.nil?
+      puts "Usage: rake import:data[file_path,model_name]"
+      puts "Example: rake import:data['db/passengers.csv','Passenger']"
+      exit
+    end
+
+    unless File.exist?(file_path)
+      puts "CSV file not found at #{file_path}"
+      exit
+    end
+
+    begin
+      model_class = model_name.constantize
+    rescue NameError
+      puts "#{model_name} is not a valid ActiveRecord model."
+      exit
+    end
+
+    puts "Importing data from #{file_path} into #{model_name}..."
+
+    CSV.foreach(file_path, headers: true) do |row|
+      attributes = row.to_h.transform_keys { |key| key.parameterize.underscore }
+      formatted_attributes = {}
+
+      # Process attributes dynamically, handling special cases
+      attributes.each do |key, value|
+        column_type = model_class.columns_hash[key]&.type
+
+        formatted_attributes[key] =
+          case column_type
+          when :integer then value.to_i if value.present?
+          when :decimal, :float then value.to_f if value.present?
+          when :boolean then value.downcase.in?(%w[true t yes y 1]) if value.present?
+          when :date then Date.strptime(value, "%m/%d/%Y") rescue nil if value.present?
+          when :datetime then DateTime.parse(value) rescue nil if value.present?
+          else value.presence
+          end
+      end
+
+      puts "Row Data: #{formatted_attributes}"
+      model_class.create!(formatted_attributes)
+    end
+
+    puts "Import complete!"
+  end
+end

--- a/lib/tasks/import_fake_data.rake
+++ b/lib/tasks/import_fake_data.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "csv"
 
 namespace :import do


### PR DESCRIPTION
- Fixed rides schema issue -- there were 2 'create_table' migrations for rides, preventing the 2nd version being the updated version. Rolled back and got rid of the first migration.
- Adjusted rides' migration from using "<column_name>" to symbols :column_name
- Changed 'confirmed_w/_passenger' to 'confirmed_with_passenger' in 'fake_rides_csv'. Current import fake_data script or ruby/rails mechanics does not recognize the slash, causing an error when trying to import fake data. 
- Renamed 'final_fake_rides_data' to 'dont_use_fake_ride_data' since we don't use this version. Can probably get rid of this file later

