### PR TITLE
[DRAFT] [feat] 81 Tables Display Relevant Info

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,7 +2,7 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 
-// Generate checkboxes for showing/hiding DataTable columns
+// Generates checkboxes for showing/hiding DataTable columns
 const initiateCheckboxes = (table) => {
   const columnToggleContainer = document.getElementById('column-toggle-container');
   columnToggleContainer.innerHTML = '';
@@ -26,11 +26,28 @@ const initiateCheckboxes = (table) => {
   });
 };
 
-document.addEventListener('turbo:load', () => {
+// Generates search bars for searching of each column of datatables
+const initiateSearchbars = (table) => {
+  table.columns('.text-filter').every(function () {
+    const column = this;
+  
+    // Create search input element and append it to the table
+    $('<input type="text"/>')
+      .attr('placeholder', `Search ${column.header().textContent.trim()}...`)
+      .appendTo(column.footer())
+      .on('keyup change clear', function () {
+        if (column.search() !== this.value) {
+          column.search(this.value).draw();
+        }
+      });
+  });
+}
 
+// Creates the Datatables
+const initiateDatatables = () => {
   const tables = [
-    { selector: '#passengers-table', order: [[2, 'asc']], searchPlaceholder: "Search passengers..." },
-    { selector: '#rides-table', order: [[2, 'desc']], searchPlaceholder: "Search rides..." }
+    { selector: '#passengers-table', order: [[2, 'asc']]},
+    { selector: '#rides-table', order: [[2, 'desc']]}
   ];
 
   tables.forEach(table => {
@@ -39,16 +56,12 @@ document.addEventListener('turbo:load', () => {
       if ($.fn.DataTable.isDataTable(table.selector)) {
         $(table.selector).DataTable().destroy();
       }
-
       const newTable = $(table.selector).DataTable({
         paging: true,
         searching: true,
         ordering: true,
         pageLength: 10,
         order: table.order,
-        language: {
-          searchPlaceholder: table.searchPlaceholder
-        },
         scrollX: true,
 
         buttons: [
@@ -63,13 +76,18 @@ document.addEventListener('turbo:load', () => {
             }
           },
         ],
-        dom: "<'row'<'col-md-6'l><'col-md-6'Bf>>" +
+        dom: "<'row'<'col-md-6'l><'col-md-6'B>>" +
           "<'row'<'col-md-12'tr>>" +
           "<'row'<'col-md-6'i><'col-md-6'p>>",
       });
       initiateCheckboxes(newTable);
+      initiateSearchbars(newTable);
     }
   });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initiateDatatables();
 
   // Flash message auto-hide after 5 seconds
   const flashMessage = document.querySelector(".alert");

--- a/app/views/passengers/_passenger.html.erb
+++ b/app/views/passengers/_passenger.html.erb
@@ -86,6 +86,21 @@
               <th class="border-0"></th>
               <th class="border-0"></th>
             </tr>
+            <tr class="column-summary">
+              <th></th>
+              <th></th>
+              <th class="summary-count"></th>
+              <th class="summary-amount"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+            </tr>
           </tfoot>
 
         </table>

--- a/app/views/passengers/_passenger.html.erb
+++ b/app/views/passengers/_passenger.html.erb
@@ -14,19 +14,20 @@
             <tr class="border-0">
               <th class="border-0"></th> <!-- Info Button -->
               <th class="border-0"></th> <!-- Delete Button -->
-              <th class="border-0">Name</th>
-              <th class="border-0">Address</th>
-              <th class="border-0">Phone</th>
-              <th class="border-0">Alternative Phone</th>
-              <th class="border-0">Birthday</th>
-              <th class="border-0">Race</th>
-              <th class="border-0">Hispanic</th>
-              <th class="border-0">Email</th>
-              <th class="border-0">Notes</th>
-              <th class="border-0">Date Registered</th>
-              <th class="border-0">Audit</th>
+              <th class="border-0 text-filter">Name</th>
+              <th class="border-0 text-filter">Address</th>
+              <th class="border-0 text-filter">Phone</th>
+              <th class="border-0 text-filter">Alternative Phone</th>
+              <th class="border-0 text-filter">Birthday</th>
+              <th class="border-0 text-filter">Race</th>
+              <th class="border-0 text-filter">Hispanic</th>
+              <th class="border-0 text-filter">Email</th>
+              <th class="border-0 text-filter">Notes</th>
+              <th class="border-0 text-filter">Date Registered</th>
+              <th class="border-0 text-filter">Audit</th>
             </tr>
           </thead>
+
           
           <tbody>
             <% @passengers.each do |passenger| %>
@@ -68,6 +69,25 @@
               </tr>
             <% end %>
           </tbody>
+
+          <tfoot>
+            <tr class="border-0">
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+            </tr>
+          </tfoot>
+
         </table>
     </div>
   </div>

--- a/app/views/rides/_ride.html.erb
+++ b/app/views/rides/_ride.html.erb
@@ -14,19 +14,18 @@
             <tr class="border-0">
               <th class="border-0"></th> <!-- Info Button -->
               <th class="border-0"></th> <!-- Delete Button -->
-
-              <th class="border-0">Date</th>
-              <th class="border-0">Driver</th>
-              <th class="border-0">Van</th>
-              <th class="border-0">Passenger Name</th>
-              <th class="border-0">Origin</th>
-              <th class="border-0">Destination</th>
-              <th class="border-0">Notes</th>
-              <th class="border-0">Hours</th>
-              <th class="border-0">Amount Paid</th>
-              <th class="border-0">Date Reserved Notes</th>
-              <th class="border-0">Confirmed with Passenger</th>
-              <th class="border-0">Emailed Driver?</th>
+              <th class="border-0 text-filter">Date</th>
+              <th class="border-0 text-filter">Driver</th>
+              <th class="border-0 text-filter">Van</th>
+              <th class="border-0 text-filter">Passenger Name</th>
+              <th class="border-0 text-filter">Origin</th>
+              <th class="border-0 text-filter">Destination</th>
+              <th class="border-0 text-filter">Notes</th>
+              <th class="border-0 text-filter">Hours</th>
+              <th class="border-0 text-filter">Amount Paid</th>
+              <th class="border-0 text-filter">Date Reserved Notes</th>
+              <th class="border-0 text-filter">Confirmed with Passenger</th>
+              <th class="border-0 text-filter">Emailed Driver?</th>
             </tr>
           </thead>
 
@@ -66,6 +65,24 @@
               </tr>
             <% end %>
           </tbody>
+          <tfoot>
+            <tr class="border-0">
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+              <th class="border-0"></th>
+            </tr>
+          </tfoot>
         </table>
       </div>
   </div>

--- a/app/views/rides/_ride.html.erb
+++ b/app/views/rides/_ride.html.erb
@@ -82,6 +82,22 @@
               <th class="border-0"></th>
               <th class="border-0"></th>
             </tr>
+            <tr class="column-summary">
+              <th></th>
+              <th></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-amount"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+              <th class="summary-count"></th>
+            </tr>
           </tfoot>
         </table>
       </div>


### PR DESCRIPTION
Changes:
- removed buttons for exporting tables as pdf, csv, etc.
- Table footers for both tables that show:
- the total sum of money for the 'amounts paid' column of the Rides table
- the percentage of entries of each city for the columns containing addresses
- the number of entries for the rest of the columns

Current issues:
- Columns are not aligned when tables are first loaded, only becomes aligned when user does an action on the table (i.e. sorting, searching, etc)
- Number of entries includes empty rows
- Number of entries shows up for the info and delete buttons' columns