### PR TITLE
101 allow admin to delete all users with no assigned role

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -29,6 +29,14 @@ class Admin::UsersController < ApplicationController
     end
   end
 
+  def destroy_unassigned
+    # Search for users with nil or empty role, delete them, return the count number
+    deleted_count = User.where(role: [nil, ""]).delete_all
+
+    # Redirects back to the admin users index page with a flash message
+    redirect_to admin_users_path, notice: "#{deleted_count} unassigned users removed."
+  end
+
   private
   def user_params
     permitted = [:email, :password]

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,15 @@
 <h1>All Users</h1>
+
+<div class="unassigned-user-actions mb-3">
+  <%= button_to "Remove All Unassigned Users",
+                destroy_unassigned_admin_users_path,
+                method: :delete,
+                data: {
+                  turbo_confirm: "Are you sure you want to delete all users with no assigned role?\nThis action cannot be undone!\nUsers with assigned roles will not be affected."
+                },
+                class: "btn btn-danger" %>
+</div>
+
 <table>
   <tr>
     <th>Email</th>

--- a/app/views/drivers/index.html.erb
+++ b/app/views/drivers/index.html.erb
@@ -2,10 +2,11 @@
   <h1 class="mb-4">Drivers</h1>
 
   <!-- UI Buttons -->
-  <div class="mb-3">
-    <%= link_to "New Driver", new_driver_path, class: "btn btn-primary" %>
-  </div>
-
+  <% if current_user.dispatcher? || current_user.admin? %>
+    <div class="mb-3">
+      <%= link_to "New Driver", new_driver_path, class: "btn btn-primary" %>
+    </div>
+  <% end %>
   <%= render 'driver' %>
 
 </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
         <span class="vr" style="width:5px ; height: 50px; currentColor: #fff; opacity: 1;"></span>
       <% end %>
 
-        <% if current_user.dispatcher? || current_user.admin? %>
+      <% if current_user.dispatcher? || current_user.admin? %>
         <%= link_to "Passengers", passengers_path, class: "passengers-link #{'active' if current_page?(passengers_path)}" %>
         <%= link_to "Rides", rides_path, class: "rides-link #{'active' if current_page?(rides_path)}" %>
         <%= link_to "Calendar", shifts_path, class: "shifts-link #{'active' if current_page?(shifts_path)}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   namespace :admin do
-    resources :users, only: [:index, :edit, :update, :destroy]
+    resources :users, only: [:index, :edit, :update, :destroy] do
+      collection do
+        delete :destroy_unassigned
+      end
+    end
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -80,11 +80,56 @@ RSpec.describe Admin::UsersController, type: :controller do
     end
   end
 
+  describe "DELETE #destroy_unassigned" do
+    it "deletes all users with no assigned role" do
+      FactoryBot.create(:user, role: nil)
+      FactoryBot.create(:user, role: "")
+      FactoryBot.create(:user, role: "dispatcher") # Should not be deleted
+      FactoryBot.create(:user, role: "driver") # Should not be deleted
+
+      expect {
+        delete :destroy_unassigned
+      }.to change { User.where(role: [nil, ""]).count }.from(2).to(0)
+
+      expect(response).to redirect_to(admin_users_path)
+      expect(flash[:notice]).to eq("2 unassigned users removed.")
+    end
+
+    it "does not delete users with valid roles" do
+      driver1 = FactoryBot.create(:user, role: "driver")
+      dispatcher1 = FactoryBot.create(:user, role: "dispatcher")
+
+      delete :destroy_unassigned
+
+      expect(User.exists?(driver1.id)).to be true
+      expect(User.exists?(dispatcher1.id)).to be true
+    end
+
+    it "redirects to admin_users_path with proper notice when no unassigned users" do
+      FactoryBot.create(:user, role: "admin")
+      FactoryBot.create(:user, role: "driver")
+
+      delete :destroy_unassigned
+
+      expect(response).to redirect_to(admin_users_path)
+      expect(flash[:notice]).to eq("0 unassigned users removed.")
+    end
+  end
+
   describe "access control" do
     it "redirects non-admin user to root with alert" do
       sign_out @admin
       sign_in @regular_user
       get :index
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("Access denied.")
+    end
+
+    it "does not allow non-admins to access destroy_unassigned" do
+      sign_out @admin
+      sign_in @regular_user
+
+      delete :destroy_unassigned
       expect(response).to redirect_to(root_path)
       expect(flash[:alert]).to eq("Access denied.")
     end


### PR DESCRIPTION
The administrator can click a button to clear users who have no assigned roles