### PR TITLE
124 structure make rides associated with shifts

### DIFF
--- a/app/controllers/drivers_controller.rb
+++ b/app/controllers/drivers_controller.rb
@@ -38,8 +38,8 @@ class DriversController < ApplicationController
                       Time.zone.today
                     end
 
-    @rides = @driver.rides.where(date: @current_date)
     @shift = @driver.shifts.where(date: @current_date).first
+    @rides = @driver.rides.where(shift: @shift)
   end
 
   # GET /drivers/1 or /drivers/1.json

--- a/app/controllers/drivers_controller.rb
+++ b/app/controllers/drivers_controller.rb
@@ -39,7 +39,7 @@ class DriversController < ApplicationController
                     end
 
     @rides = @driver.rides.where(date: @current_date)
-    @shift = @driver.shifts.where(shift_date: @current_date).first
+    @shift = @driver.shifts.where(date: @current_date).first
   end
 
   # GET /drivers/1 or /drivers/1.json

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -19,7 +19,7 @@ class FeedbacksController < ApplicationController
 
   # GET /feedbacks/1/edit
   def edit
-    @current_date = @feedback.ride.date
+    @current_date = @feedback.ride.shift.date
     @passenger = @feedback.ride.passenger.name
   end
 

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -99,17 +99,15 @@ class RidesController < ApplicationController
 
   def ride_params
     params.require(:ride).permit(
-      :shift_id,
-      :van,
       :hours,
       :amount_paid,
       :notes_date_reserved,
       :confirmed_with_passenger,
       :passenger_id,
       :notes,
+      :shift_id,
       :start_address_id,
       :dest_address_id,
-      :shift_id,
       start_address_attributes: [:street, :city, :state, :zip],
       dest_address_attributes: [:street, :city, :state, :zip]
     )

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -8,12 +8,12 @@ class ShiftsController < ApplicationController
   def index
     # @shifts = Shift.all
     @date = params[:start_date] ? Date.parse(params[:start_date]) : Date.today
-    @shifts = Shift.where(shift_date: @date.beginning_of_month..@date.end_of_month)
+    @shifts = Shift.where(date: @date.beginning_of_month..@date.end_of_month)
   end
 
   # GET /shifts/1 or /shifts/1.json
   def show
-    @rides = Ride.where(date: @shift.shift_date)
+    @rides = Ride.where(date: @shift.date)
   end
 
   # GET /shifts/new
@@ -89,6 +89,6 @@ class ShiftsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def shift_params
-    params.require(:shift).permit(:shift_date, :shift_type, :driver_id, :van, :notes, :pick_up_time, :drop_off_time, :odometer_pre, :odometer_post)
+    params.require(:shift).permit(:date, :shift_type, :driver_id, :van, :notes, :pick_up_time, :drop_off_time, :odometer_pre, :odometer_post)
   end
 end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -13,7 +13,7 @@ class ShiftsController < ApplicationController
 
   # GET /shifts/1 or /shifts/1.json
   def show
-    @rides = Ride.where(date: @shift.date)
+    @rides = @shift.rides
   end
 
   # GET /shifts/new
@@ -79,6 +79,12 @@ class ShiftsController < ApplicationController
       format.html { redirect_to shifts_path, status: :see_other, notice: "Shift was successfully destroyed." }
       format.json { head :no_content }
     end
+  end
+
+  def shifts_for_day
+    @shifts = Shift.where(date: params[:date])
+    @prompt = @shifts.empty? ? "No shifts for that day" : "Select a shift"
+    render :shifts_for_day
   end
 
   private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,4 +3,5 @@ import "@hotwired/turbo-rails"
 import "controllers"
 import "datatables"
 import "autocomplete"
+import "new_ride_shift_selector"
 

--- a/app/javascript/new_ride_shift_selector.js
+++ b/app/javascript/new_ride_shift_selector.js
@@ -1,0 +1,55 @@
+  
+function get_and_set_shifts(date, chosen_shift=null) {
+    var request = $.ajax({
+        url: "/shifts/shifts_for_day",
+        data: { date: date },
+        dataType: "json"
+      });
+       
+    request.done(function( new_options ) {
+        var $el = $("#ride_shift_id");
+
+        $el.empty();
+        $.each(new_options, function(index) {
+            var option =  new_options[index];
+            $el.append($("<option></option>").attr("value", option.value).text(option.text));
+            });
+        if (chosen_shift) {
+            $(`#ride_shift_id option[value="${chosen_shift}"]`).attr('selected', true);
+        }
+      });
+}
+
+
+document.addEventListener('change', (event) => {
+    if (event.target.matches('#ride_shift_date')) {
+        get_and_set_shifts(event.target.value)
+    }
+});
+
+
+// if you come from a shift page, it should automatically select that shift for you
+document.addEventListener('turbo:load', function() {
+    //check if we're on the new ride page
+    if (document.getElementById("ride_passenger_name")){
+        var date = $("#ride_shift_date").attr("value")
+        if (date){   
+            var shift_id = $("#ride_shift_id").attr("value")
+            get_and_set_shifts(date, shift_id)
+        }
+    }
+});
+
+
+// // stolen from: https://stackoverflow.com/a/6364838
+// var new_options = response.options;
+
+// /* Remove all options from the select list */
+// $('yourSelectList').empty();
+
+// /* Insert the new ones from the array above */
+// $.each(new_options, function(value) {
+//     new Element('option')
+//         .set('text', value)
+//         .inject($('yourSelectList'));
+//     });

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Driver < ApplicationRecord
-  has_many :rides, dependent: :nullify
   has_many :shifts, dependent: :destroy
+  has_many :rides, through: :shifts
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -12,7 +12,7 @@ class Ride < ApplicationRecord
   accepts_nested_attributes_for :dest_address
 
   def emailed_driver?
-    self.emailed_driver == "true"
+    self.shift.emailed_driver == "true"
   end
 
   # # Filtering logic for rides table

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -3,7 +3,8 @@
 class Ride < ApplicationRecord
   has_one :feedback
   belongs_to :passenger, optional: true
-  belongs_to :driver
+  belongs_to :shift
+  has_one :driver, through: :shift
   belongs_to :start_address, class_name: "Address", foreign_key: :start_address_id
   belongs_to :dest_address, class_name: "Address", foreign_key: :dest_address_id
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -2,10 +2,10 @@
 
 class Shift < ApplicationRecord
   belongs_to :driver
-  validates :shift_date, :shift_type, presence: true
+  validates :date, :shift_type, presence: true
 
-  def self.shifts_by_date(shifts, shift_date)
-    shifts.where(shift_date: shift_date)
+  def self.shifts_by_date(shifts, date)
+    shifts.where(date: date)
   end
 
   def self.shifts_by_driver(shifts, driver_id)

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -3,6 +3,7 @@
 class Shift < ApplicationRecord
   belongs_to :driver
   validates :date, :shift_type, presence: true
+  has_many :rides, dependent: :nullify
 
   def self.shifts_by_date(shifts, date)
     shifts.where(date: date)

--- a/app/views/drivers/all_shifts.html.erb
+++ b/app/views/drivers/all_shifts.html.erb
@@ -6,7 +6,7 @@
   <% @shifts.each do |shift| %>
   <div class="shift">
     <li>
-      <strong>Shift date:</strong> <%= shift.shift_date %>,
+      <strong>Shift date:</strong> <%= shift.date %>,
       <strong>Shift type:</strong> <%= shift.shift_type %>
       <%= link_to "View Shift", shift_path(shift) %>
     </li>

--- a/app/views/drivers/today.html.erb
+++ b/app/views/drivers/today.html.erb
@@ -28,7 +28,7 @@
         <tbody>
           <% @rides.each do |ride| %>
             <tr>
-              <td><%= ride.van %></td>
+              <td><%= ride.shift.van %></td>
               <td><%= ride.notes %></td>
               <td><%= ride.hours %></td>
               <td><%= number_to_currency(ride.amount_paid) %></td>
@@ -43,7 +43,7 @@
       <div class="rides-list">
         <% @rides.each do |ride| %>
           <div class="ride-block">
-            <p><strong>Van:</strong> <%= ride.van %></p>
+            <p><strong>Van:</strong> <%= ride.shift.van %></p>
             <p><strong>Notes:</strong> <%= ride.notes %></p>
             <p><strong>Hours:</strong> <%= ride.hours %></p>
             <p><strong>Fee:</strong> <%= number_to_currency(ride.amount_paid) %></p>

--- a/app/views/drivers/today.html.erb
+++ b/app/views/drivers/today.html.erb
@@ -56,7 +56,7 @@
     <p class="no-rides">No rides available</p>
   <% end %>
 
-  <% shift_today = Shift.find_by(driver_id: @driver.id, shift_date: @current_date) %>
+  <% shift_today = Shift.find_by(driver_id: @driver.id, date: @current_date) %>
   <% if shift_today %>
     <div class="shift-notes">
       <h3>Timeline & Notes</h3>

--- a/app/views/rides/_ride.html.erb
+++ b/app/views/rides/_ride.html.erb
@@ -52,7 +52,7 @@
                 </td>
 
                 <td><%= ride.date %></td>
-                <td><%= ride.driver&.name || 'N/A' %></td>
+                <td><%= ride.shift.driver&.name || 'N/A' %></td>
                 <td><%= ride.van || 'N/A' %></td>
                 <td><%= ride.passenger&.name || 'N/A' %></td>
                 <td><%= ride.start_address&.full_address || 'N/A' %></td>
@@ -81,7 +81,7 @@
                 </td>
 
                 <td>
-                  <% if ride.emailed_driver.to_s.downcase == "sent" %>
+                  <% if ride.shift.emailed_driver.to_s.downcase == "sent" %>
                     <span class="badge bg-success">Yes</span>
                   <% else %>
                     <span class="badge bg-danger">No</span>

--- a/app/views/rides/new.html.erb
+++ b/app/views/rides/new.html.erb
@@ -28,35 +28,22 @@
           <div class="col-md-6 border-end">
             <h5 class="fw-bold text-success">Ride Details</h5>
 
-            <div class="mb-3">
-              <%= f.label :date, "Date" %> <span class="text-danger">*</span>
-              <%= f.date_field :date, class: "form-control", required: true %>
-            </div>
+              <div class="mb-3">
+                <%= f.label :shift_date, "Date" %> <span class="text-danger">*</span>
+                <%= f.date_field :shift_date, class: "form-control", required: true, value: (@ride.shift ? @ride.shift.date : nil) %>
+              </div>
 
-            <div class="mb-3">
-              <%= f.label :driver_id, "Driver" %>
-              <%= f.select :driver_id,
-                           options_from_collection_for_select(@drivers, :id, :name, @ride.driver_id),
-                           { prompt: "Select a Driver" },
-                           { class: "form-select", required: true  }%>
-            </div>
-
-            <div class="mb-3">
-              <%= f.label :van, "Van" %>
-              <%= f.number_field :van, class: "form-control" %>
-            </div>
+              <div class="mb-3">
+                <%= f.label :shift_id, "Select Shift" %>
+                <%= f.select :shift_id,
+                           [],
+                           { prompt: "Select a date first" },
+                           { class: "form-select", required: true, value: (@ride.shift ? @ride.shift.id : nil) }%>
+              </div>
 
             <div class="mb-3">
               <%= f.label :notes, "Notes" %>
               <%= f.text_area :notes, class: "form-control", rows: 3 %>
-            </div>
-
-            <div class="mb-3">
-              <%= f.label :emailed_driver, "Emailed Driver?", class: "form-label" %>
-              <%= f.select :emailed_driver,
-                           [["Yes", true], ["No", false]],
-                           {},
-                           class: "form-select", required: true %>
             </div>
           </div>
 

--- a/app/views/rides/show.html.erb
+++ b/app/views/rides/show.html.erb
@@ -5,8 +5,9 @@
     <div class="card-body">
       <h5 class="card-title">Basic Info</h5>
       <ul class="list-group list-group-flush">
-        <li class="list-group-item"><strong>Date:</strong> <%= @ride.date.strftime("%B %d, %Y") %></li>
-        <li class="list-group-item"><strong>Van Number:</strong> <%= @ride.van %></li>
+        <li class="list-group-item"><strong>Date:</strong> <%= @ride.shift.date.strftime("%B %d, %Y") %></li>
+        <li class="list-group-item"><strong>Shift:</strong> <%= @ride.shift.shift_type %></li>
+        <li class="list-group-item"><strong>Van Number:</strong> <%= @ride.shift.van %></li>
         <li class="list-group-item"><strong>Hours:</strong> <%= @ride.hours %></li>
         <li class="list-group-item"><strong>Amount Paid:</strong> <%= number_to_currency(@ride.amount_paid) %></li>
       </ul>
@@ -18,7 +19,7 @@
       <h5 class="card-title">People</h5>
       <ul class="list-group list-group-flush">
         <li class="list-group-item"><strong>Passenger:</strong> <%= @ride.passenger&.name || "Not Assigned" %></li>
-        <li class="list-group-item"><strong>Driver:</strong> <%= @ride.driver&.name || "Not Assigned" %></li>
+        <li class="list-group-item"><strong>Driver:</strong> <%= @ride.shift.driver&.name || "Not Assigned" %></li>
       </ul>
     </div>
   </div>
@@ -54,7 +55,7 @@
         <li class="list-group-item"><strong>General Notes:</strong> <%= simple_format(@ride.notes) %></li>
         <li class="list-group-item"><strong>Notes (Date Reserved):</strong> <%= simple_format(@ride.notes_date_reserved) %></li>
         <li class="list-group-item"><strong>Confirmed with Passenger:</strong> <%= simple_format(@ride.confirmed_with_passenger) %></li>
-        <li class="list-group-item"><strong>Emailed Driver:</strong> <%= @ride.emailed_driver.present? ? "Yes" : "No" %></li>
+        <li class="list-group-item"><strong>Emailed Driver:</strong> <%= @ride.shift.emailed_driver.present? ? "Yes" : "No" %></li>
       </ul>
     </div>
   </div>

--- a/app/views/shifts/_form.html.erb
+++ b/app/views/shifts/_form.html.erb
@@ -12,10 +12,8 @@
   <% end %>
 
   <div>
-    <%= form.label :shift_date, style: "display: block" %>
-    <%# Rails will automatically generate shift_date filed id as "shift_shift_date" %>
-    <%# Unless we rename the model field later %>
-    <%= form.date_field :shift_date, required: true, :value => params[:date] || shift.shift_date %>
+    <%= form.label :date, style: "display: block" %>
+    <%= form.date_field :date, required: true, :value => params[:date] || shift.date %>
   </div>
 
   <div>

--- a/app/views/shifts/_shift.html.erb
+++ b/app/views/shifts/_shift.html.erb
@@ -3,7 +3,7 @@
   <div class="van-col">
     <p>
       <strong>Shift date:</strong>
-      <%= shift.shift_date %>
+      <%= shift.date %>
     </p>
     <p>
       <strong>Driver name:</strong>

--- a/app/views/shifts/_shift.json.jbuilder
+++ b/app/views/shifts/_shift.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! shift, :id, :shift_date, :shift_type, :created_at, :updated_at
+json.extract! shift, :id, :date, :shift_type, :created_at, :updated_at
 json.url shift_url(shift, format: :json)

--- a/app/views/shifts/feedback.html.erb
+++ b/app/views/shifts/feedback.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Shift Feedback" %>
 
-<h1>Feedback for <%= @shift.shift_type %> shift on <%= @shift.shift_date %></h1>
+<h1>Feedback for <%= @shift.shift_type %> shift on <%= @shift.date %></h1>
 
 <%= form_with(model: @shift) do |form| %>
   <% if @shift.errors.any? %>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -9,7 +9,7 @@
 <div id="shifts-calendar">
   <%# The following line starts with the following parameter which can be replaced by
   'week_calendar' or 'month_calendar' or 'calendar' %>
-  <%= month_calendar(attribute: :shift_date, events: @shifts, start_day: :sunday) do |date, shifts| %>
+  <%= month_calendar(attribute: :date, events: @shifts, start_day: :sunday) do |date, shifts| %>
     <%= date %>
 
     <% if date.month == @date.month && date.year == @date.year && (current_user.admin? || current_user.dispatcher?) %>

--- a/app/views/shifts/shifts_for_day.jbuilder
+++ b/app/views/shifts/shifts_for_day.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+select_options = [{ value: nil, text: @prompt }]
+
+select_options += @shifts.map do |shift|
+  { text: "#{shift.shift_type} shift with driver #{shift.driver.name}", value: shift.id }
+end
+
+json.array! select_options

--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -7,7 +7,7 @@
 <%= render "shift_rides" %>
 
 <div class="text-right mt-4">
-  <%= link_to "Add new ride", new_ride_path(date: @shift.shift_date, driver_id: @shift.driver), class: "btn btn-primary" %>
+  <%= link_to "Add new ride", new_ride_path(date: @shift.date, driver_id: @shift.driver), class: "btn btn-primary" %>
 </div>
 
 

--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -7,7 +7,7 @@
 <%= render "shift_rides" %>
 
 <div class="text-right mt-4">
-  <%= link_to "Add new ride", new_ride_path(date: @shift.date, driver_id: @shift.driver), class: "btn btn-primary" %>
+  <%= link_to "Add new ride", new_ride_path(shift_id: @shift.id), class: "btn btn-primary" %>
 </div>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
     member do
       get "feedback"
     end
+    collection do
+      get "shifts_for_day" # for new ride shift selector javascript
+    end
   end
 
   resources :drivers do

--- a/db/migrate/20250427224740_rename_date_in_shifts.rb
+++ b/db/migrate/20250427224740_rename_date_in_shifts.rb
@@ -1,0 +1,6 @@
+class RenameDateInShifts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :shifts, :date, :date
+    remove_column :shifts, :shift_date, :date
+  end
+end

--- a/db/migrate/20250427231410_add_shift_ref_to_rides.rb
+++ b/db/migrate/20250427231410_add_shift_ref_to_rides.rb
@@ -1,0 +1,11 @@
+class AddShiftRefToRides < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :rides, :date, :date
+    remove_column :rides, :van, :integer
+    remove_reference :rides, :driver, index: true
+    remove_column :rides, :emailed_driver, :binary
+    add_reference :rides, :shift, foreign_key: true
+
+    remove_column :shifts, :emailed_driver, :binary
+  end
+end

--- a/db/migrate/20250427231410_add_shift_ref_to_rides.rb
+++ b/db/migrate/20250427231410_add_shift_ref_to_rides.rb
@@ -6,6 +6,6 @@ class AddShiftRefToRides < ActiveRecord::Migration[7.2]
     remove_column :rides, :emailed_driver, :binary
     add_reference :rides, :shift, foreign_key: true
 
-    remove_column :shifts, :emailed_driver, :binary
+    add_column :shifts, :emailed_driver, :binary
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_17_221441) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_27_224740) do
   create_table "addresses", force: :cascade do |t|
     t.string "street"
     t.string "city"
@@ -147,7 +147,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_17_221441) do
   end
 
   create_table "shifts", force: :cascade do |t|
-    t.date "shift_date"
     t.string "shift_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -158,6 +157,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_17_221441) do
     t.string "odometer_pre"
     t.string "odometer_post"
     t.text "notes"
+    t.date "date"
     t.index ["driver_id"], name: "index_shifts_on_driver_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -138,7 +138,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_231410) do
     t.boolean "low_income", default: false, null: false
     t.boolean "disabled", default: false, null: false
     t.boolean "need_caregiver", default: false, null: false
+    t.integer "next_ride_id"
     t.integer "shift_id"
+    t.index ["next_ride_id"], name: "index_rides_on_next_ride_id"
     t.index ["passenger_id"], name: "index_rides_on_passenger_id"
     t.index ["shift_id"], name: "index_rides_on_shift_id"
   end
@@ -155,6 +157,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_231410) do
     t.string "odometer_post"
     t.text "notes"
     t.date "date"
+    t.binary "emailed_driver"
     t.index ["driver_id"], name: "index_shifts_on_driver_id"
   end
 
@@ -174,6 +177,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_231410) do
   add_foreign_key "feedbacks", "rides"
   add_foreign_key "passengers", "addresses"
   add_foreign_key "rides", "passengers"
+  add_foreign_key "rides", "rides", column: "next_ride_id"
   add_foreign_key "rides", "shifts"
   add_foreign_key "shifts", "drivers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_27_224740) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_27_231410) do
   create_table "addresses", force: :cascade do |t|
     t.string "street"
     t.string "city"
@@ -121,8 +121,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_224740) do
   end
 
   create_table "rides", force: :cascade do |t|
-    t.date "date", null: false
-    t.integer "van"
     t.float "hours"
     t.decimal "amount_paid", precision: 10, scale: 2
     t.text "notes_date_reserved"
@@ -130,9 +128,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_224740) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "passenger_id"
-    t.integer "driver_id"
     t.text "notes"
-    t.binary "emailed_driver"
     t.integer "start_address_id"
     t.integer "dest_address_id"
     t.string "address_name"
@@ -142,8 +138,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_224740) do
     t.boolean "low_income", default: false, null: false
     t.boolean "disabled", default: false, null: false
     t.boolean "need_caregiver", default: false, null: false
-    t.index ["driver_id"], name: "index_rides_on_driver_id"
+    t.integer "shift_id"
     t.index ["passenger_id"], name: "index_rides_on_passenger_id"
+    t.index ["shift_id"], name: "index_rides_on_shift_id"
   end
 
   create_table "shifts", force: :cascade do |t|
@@ -176,7 +173,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_27_224740) do
 
   add_foreign_key "feedbacks", "rides"
   add_foreign_key "passengers", "addresses"
-  add_foreign_key "rides", "drivers"
   add_foreign_key "rides", "passengers"
+  add_foreign_key "rides", "shifts"
   add_foreign_key "shifts", "drivers"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,9 +52,9 @@ end
   driver_id_am = day.mday % 6
   driver_id_pm = (day.mday + 1) % 5
   if day.wday in (1..5)
-    if Shift.where(shift_date: day).empty?
-      Shift.create!(shift_date: day, shift_type: "am", driver: drivers[driver_id_am])
-      Shift.create!(shift_date: day, shift_type: "pm", driver: drivers[driver_id_pm])
+    if Shift.where(date: day).empty?
+      Shift.create!(date: day, shift_type: "am", driver: drivers[driver_id_am])
+      Shift.create!(date: day, shift_type: "pm", driver: drivers[driver_id_pm])
     end
   end
 end

--- a/features/dispatcher/dispatcher_shift_navigation.feature
+++ b/features/dispatcher/dispatcher_shift_navigation.feature
@@ -11,7 +11,7 @@ Feature: Dispatcher Shift Navigation
       | name       |
       | John Smith |
     And the following shift exists:
-      | driver     | shift_date | shift_type |
+      | driver     | date | shift_type |
       | John Smith | Time.zone.today | am |
     And I am on the shifts calendar page
 

--- a/features/step_definitions/dispatcher_data_setup_steps.rb
+++ b/features/step_definitions/dispatcher_data_setup_steps.rb
@@ -9,15 +9,15 @@ end
 Given("the following shift exists:") do |table|
   table.hashes.each do |row|
     driver = Driver.find_by(name: row["driver"])
-    shift_date =
-      if row["shift_date"] == "Time.zone.today"
+    date =
+      if row["date"] == "Time.zone.today"
         Time.zone.today
       else
-        Date.parse(row["shift_date"])
+        Date.parse(row["date"])
       end
     Shift.create!(
       driver: driver,
-      shift_date: shift_date,
+      date: date,
       shift_type: row["shift_type"]
     )
   end

--- a/features/step_definitions/dispatcher_shift_steps.rb
+++ b/features/step_definitions/dispatcher_shift_steps.rb
@@ -24,7 +24,7 @@ When("I click one day's {string} button") do |button_text|
 end
 
 Then("the shift date field should show the date of the day I selected") do
-  input_value = find("#shift_shift_date").value
+  input_value = find("#shift_date").value
   expect(input_value).to eq @clicked_date.to_s
 end
 

--- a/spec/controllers/drivers_controller_spec.rb
+++ b/spec/controllers/drivers_controller_spec.rb
@@ -15,11 +15,17 @@ RSpec.describe DriversController, type: :controller do
 
     @passenger1 = FactoryBot.create(:passenger)
     @passenger2 = FactoryBot.create(:passenger)
-    @ride1 = FactoryBot.create(:ride, driver: @driver1, passenger: @passenger1)
-    @ride2 = FactoryBot.create(:ride, driver: @driver2, passenger: @passenger1)
-    @ride3 = FactoryBot.create(:ride, driver: @driver1, passenger: @passenger2)
-    @ride4 = FactoryBot.create(:ride, driver: @driver1, passenger: @passenger1, date: Time.zone.today + 1.days)
-    @ride5 = FactoryBot.create(:ride, driver: @driver1, passenger: @passenger1, date: Time.zone.today - 1.days)
+
+    @shift1 = FactoryBot.create(:shift, driver: @driver1)
+    @shift2 = FactoryBot.create(:shift, driver: @driver2)
+    @shift1_yesterday = FactoryBot.create(:shift, driver: @driver1, date: Time.zone.today - 1.days)
+    @shift1_tomorrow = FactoryBot.create(:shift, driver: @driver1, date: Time.zone.today + 1.days)
+
+    @ride1 = FactoryBot.create(:ride, shift: @shift1, passenger: @passenger1)
+    @ride2 = FactoryBot.create(:ride, shift: @shift2, passenger: @passenger1)
+    @ride3 = FactoryBot.create(:ride, shift: @shift1, passenger: @passenger2)
+    @ride4 = FactoryBot.create(:ride, shift: @shift1_tomorrow, passenger: @passenger1)
+    @ride5 = FactoryBot.create(:ride, shift: @shift1_yesterday, passenger: @passenger1)
   end
 
   describe "Access control: driver user restrictions" do

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -10,13 +10,18 @@ RSpec.describe RidesController, type: :controller do
      @driver1 = FactoryBot.create(:driver)
      @driver2 = FactoryBot.create(:driver)
 
+     @shift1 = FactoryBot.create(:shift, driver: @driver1)
+     @shift2 = FactoryBot.create(:shift, driver: @driver2)
+     @shift_5_days_ago = FactoryBot.create(:shift, date: Date.today - 5.days)
+
+
      @address1 = FactoryBot.create(:address)
 
      @passenger1 = FactoryBot.create(:passenger)
-     @ride1 = FactoryBot.create(:ride, driver: @driver1, passenger: @passenger1)
-     @ride2 = FactoryBot.create(:ride, driver: @driver2, passenger: @passenger1)
-     @ride3 = FactoryBot.create(:ride, driver: @driver1, passenger: @passenger1)
-     @ride4 = FactoryBot.create(:ride, date: Date.today - 5.days)
+     @ride1 = FactoryBot.create(:ride, shift: @shift1, passenger: @passenger1)
+     @ride2 = FactoryBot.create(:ride, shift: @shift2, passenger: @passenger1)
+     @ride3 = FactoryBot.create(:ride, shift: @shift1, passenger: @passenger1)
+     @ride4 = FactoryBot.create(:ride, shift: @shift_5_days_ago)
    end
 
   describe "GET #index" do
@@ -31,16 +36,13 @@ RSpec.describe RidesController, type: :controller do
     context "with valid attributes" do
       let(:valid_attributes) do
         {
-          date: @ride1.date,
-          van: @ride1.van,
           hours: @ride1.hours,
           amount_paid: @ride1.amount_paid,
           notes_date_reserved: @ride1.notes_date_reserved,
           confirmed_with_passenger: @ride1.confirmed_with_passenger,
           passenger_id: @ride1.passenger_id,
-          driver_id: @ride1.driver_id,
           notes: @ride1.notes,
-          emailed_driver: @ride1.emailed_driver,
+          shift_id: @ride1.shift_id,
           start_address_id: @ride1.start_address_id,
           dest_address_id: @ride1.dest_address_id
         }

--- a/spec/controllers/shifts_controller_spec.rb
+++ b/spec/controllers/shifts_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ShiftsController, type: :controller do
     context "with valid parameters" do
       it "creates a new shift and redirects to the shift page" do
         expect {
-          post :create, params: { shift: { shift_date: Date.today, shift_type: "evening", driver_id: @driver.id } }
+          post :create, params: { shift: { date: Date.today, shift_type: "evening", driver_id: @driver.id } }
         }.to change(Shift, :count).by(1)
 
         expect(response).to redirect_to(shifts_path)
@@ -46,7 +46,7 @@ RSpec.describe ShiftsController, type: :controller do
     context "with empty shift_type" do
       it "does not create a shift and re-renders the new template" do
         expect {
-          post :create, params: { shift: { shift_date: Date.today, shift_type: "", driver_id: @driver.id } }
+          post :create, params: { shift: { date: Date.today, shift_type: "", driver_id: @driver.id } }
         }.not_to change(Shift, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -57,7 +57,7 @@ RSpec.describe ShiftsController, type: :controller do
     context "with missing driver_id" do
       it "does not create a shift and redirects to new_shift_path with an alert" do
         expect {
-          post :create, params: { shift: { shift_date: Date.today, shift_type: "evening", driver_id: nil } }
+          post :create, params: { shift: { date: Date.today, shift_type: "evening", driver_id: nil } }
         }.not_to change(Shift, :count)
 
         expect(response).to redirect_to(new_shift_path)
@@ -68,7 +68,7 @@ RSpec.describe ShiftsController, type: :controller do
     context "with invalid driver_id" do
       it "does not create a shift and redirects to new_shift_path with an alert" do
         expect {
-          post :create, params: { shift: { shift_date: Date.today, shift_type: "evening", driver_id: 9999 } }
+          post :create, params: { shift: { date: Date.today, shift_type: "evening", driver_id: 9999 } }
         }.not_to change(Shift, :count)
 
         expect(response).to redirect_to(new_shift_path)
@@ -103,9 +103,9 @@ RSpec.describe ShiftsController, type: :controller do
 
     context "with invalid parameters" do
       it "does not update the shift and re-renders the edit template" do
-        patch :update, params: { id: @shift.id, shift: { shift_date: nil } }
+        patch :update, params: { id: @shift.id, shift: { date: nil } }
         @shift.reload
-        expect(@shift.shift_date).not_to be_nil
+        expect(@shift.date).not_to be_nil
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/factories/rides.rb
+++ b/spec/factories/rides.rb
@@ -5,11 +5,8 @@ FactoryBot.define do
       association :start_address, factory: :address
       association :dest_address, factory: :address
       association :passenger
-      association :driver
-      van { 1 }
+      association :shift
       hours { 1.0 }
-      date { Time.zone.today }
       amount_paid { 0 }
-      emailed_driver { false }
     end
   end

--- a/spec/factories/shifts.rb
+++ b/spec/factories/shifts.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :shift do
     date { DateTime.now }
     shift_type { "am" }
+    emailed_driver { false }
     association :driver
   end
 end

--- a/spec/factories/shifts.rb
+++ b/spec/factories/shifts.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :shift do
-    shift_date { DateTime.now }
+    date { DateTime.now }
     shift_type { "am" }
     association :driver
   end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -10,9 +10,13 @@ RSpec.describe Ride, type: :model do
     today = Time.zone.today
     today.strftime("%a")
 
-    @ride1 = FactoryBot.create(:ride, driver: @driver1, date: Time.zone.today - 1.day, emailed_driver: true)
-    @ride2 = FactoryBot.create(:ride, driver: @driver2)
-    @ride3 = FactoryBot.create(:ride, driver: @driver1, date: Time.zone.today + 1.day)
+    @shift_yesterday = FactoryBot.create(:shift, driver: @driver1, date: Time.zone.today - 1.day, emailed_driver: true)
+    @shift_today =  FactoryBot.create(:shift, driver: @driver2)
+    @shift_tomorrow = FactoryBot.create(:shift, driver: @driver1, date: Time.zone.today + 1.day)
+
+    @ride1 = FactoryBot.create(:ride, shift: @shift_yesterday)
+    @ride2 = FactoryBot.create(:ride, shift: @shift_today)
+    @ride3 = FactoryBot.create(:ride, shift: @shift_tomorrow)
   end
 
   describe "Validations" do
@@ -89,10 +93,5 @@ RSpec.describe Ride, type: :model do
       expect(ride.dest_address.state).to eq("CA")
       expect(ride.dest_address.zip).to eq("94105")
     end
-  end
-
-  after(:each) do
-    Ride.delete_all
-    Driver.delete_all
   end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -9,24 +9,24 @@ RSpec.describe Shift, type: :model do
 
   context "validations" do
     it "is valid with valid attributes" do
-      shift = Shift.new(shift_date: Date.today, shift_type: "am", driver: @driver)
+      shift = Shift.new(date: Date.today, shift_type: "am", driver: @driver)
       expect(shift).to be_valid
     end
 
-    it "is invalid without a shift_date" do
-      shift = Shift.new(shift_date: nil, shift_type: "am", driver: @driver)
+    it "is invalid without a date" do
+      shift = Shift.new(date: nil, shift_type: "am", driver: @driver)
       expect(shift).not_to be_valid
-      expect(shift.errors[:shift_date]).to include("can't be blank")
+      expect(shift.errors[:date]).to include("can't be blank")
     end
 
     it "is invalid without a shift_type" do
-      shift = Shift.new(shift_date: Date.today, shift_type: nil, driver: @driver)
+      shift = Shift.new(date: Date.today, shift_type: nil, driver: @driver)
       expect(shift).not_to be_valid
       expect(shift.errors[:shift_type]).to include("can't be blank")
     end
 
     it "is invalid without a driver" do
-      shift = Shift.new(shift_date: Date.today, shift_type: "am", driver: nil)
+      shift = Shift.new(date: Date.today, shift_type: "am", driver: nil)
       expect(shift).not_to be_valid
       expect(shift.errors[:driver]).to include("must exist")
     end
@@ -34,8 +34,8 @@ RSpec.describe Shift, type: :model do
 
   describe ".shifts_by_date" do
     it "filters shifts by date" do
-      shift1 = FactoryBot.create(:shift, shift_date: Date.today)
-      FactoryBot.create(:shift, shift_date: Date.yesterday)
+      shift1 = FactoryBot.create(:shift, date: Date.today)
+      FactoryBot.create(:shift, date: Date.yesterday)
 
       expect(Shift.shifts_by_date(Shift.all, Date.today)).to contain_exactly(shift1)
     end
@@ -55,7 +55,7 @@ RSpec.describe Shift, type: :model do
   describe ".today_driver_shifts" do
     it "returns today's shift for a driver" do
       driver = FactoryBot.create(:driver)
-      shift = FactoryBot.create(:shift, driver: driver, shift_date: Time.zone.today)
+      shift = FactoryBot.create(:shift, driver: driver, date: Time.zone.today)
       expect(Shift.today_driver_shifts(driver.id)).to eq(shift)
     end
   end


### PR DESCRIPTION
This PR updated our ride model so now it is not directly associated with a date and driver, but instead gets those data from its associated shift.
This required making small changes in many files (eg everywhere there was `@ride.driver` had to be changed to `@ride.shift.driver`)
All the rspec and cucumber tests pass, although that isn't really a guarantee the app is completely functional.

**Additional changes:**
This issue actually ended up being much more involved than I previously thought as I had to add completely new functionality for selecting a shift when creating a new ride. Right now you select a date, and then an ajax call collects the shifts on that date and you can associate a ride to that shift. There currently is no way to create a ride without associating it to a shift. All the javascript for this was put into a new file. A bunch of work also had to be done to get it to automatically select the right shift if you came to that page from the shift view page, but it all seems to work decently well

Also, I took the opportunity to change `shift.shift_date` to simply `shift.date` because that was bothering me.