### PR TITLE
add help hutton

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -25,7 +25,8 @@
 
       <div class="navbar-user d-flex align-items-center">
         <span>Hello! <%= current_user.role %></span>
-        <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, form: { data: { turbo: 'false' } }, class: "btn btn-outline-light btn-sm ms-2" %>
+        <%= link_to "Help", "https://docs.google.com/document/d/1Xt9CL3Qm39cJFG4vccKfZf1rtManONztd83Pe-0sFGY", target: "_blank", class: "btn btn-outline-light btn-sm ms-4" %>
+        <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, form: { data: { turbo: 'false' } }, class: "btn btn-outline-light btn-sm ms-4" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
There are two main implementation approaches considered:

- Linking to an external document via link_to.
- Embedding the content within the app using a dedicated controller and view to render Markdown.

Currently, I choose the first approach for simplicity. Although using a Markdown-to-HTML renderer (e.g., via a Gem) was the other way. The documentation is still evolving and involves a nested tab structure which requires manual merging logic in code. So embedding the whole hep page content directly in the app is deferred for now.

1. The buttons are placed with space to reduce the chance of misclicking “Sign Out,” especially for drivers.

<img width="30%" alt="image" src="https://github.com/user-attachments/assets/fb72ca8a-e45f-425f-9e8e-5fce86f45ad8" />

Feel free to adjust the spacing if there are better solutions.

2. At present, the linked Google Doc is restricted to bMail users, making it inaccessible to the customers.

Possible solutions:

- Adjusting the existing document’s sharing settings.
- Creating a new document with public viewing permissions.

3. The effect of this PR can be viewed on my heroku container.  

By the way, I think the effect of viewing Google Docs via link on mobile phone is not good. The title font is too large, causing line breaks, and the content layout feels very compact. (And this problem cannot be solved because it is caused by the mobile browser display logic?) On my mobile device, the image is blurry(PC view is good, though), I don't know if this problem is universal.
<img width="30%" alt="image" src="https://github.com/user-attachments/assets/671c4be7-6a2e-4d39-bbf6-75be892e8da4" />

The layout effect is not as beautiful as that on computer. That is why professor told us better do not use link_to Google Docs, but the other way seems to complex for me...