### PR TITLE
173 rework new ride creation enhance driver tab

### DIFF
--- a/app/controllers/drivers_controller.rb
+++ b/app/controllers/drivers_controller.rb
@@ -22,9 +22,9 @@ class DriversController < ApplicationController
       end
     end
 
-    @drivers = Driver.all
-    # @drivers = @drivers.filter_by_active(params[:active])
-    # @drivers = @drivers.filter_by_name(params[:name])
+    @active_drivers = Driver.where(active: true).order(:name)
+    @inactive_drivers = Driver.where(active: false).order(:name)
+    @drivers = Driver.all # Keep this for compatibility if needed elsewhere
   end
 
   # GET /drivers/:driver_id/shifts

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -36,11 +36,12 @@ class RidesController < ApplicationController
       street: p.address&.street, city: p.address&.city
     } }
     gon.addresses = Address.all.map { |a| { name: a.name, street: a.street, city: a.city, phone: a.phone } }
+    gon.drivers = @drivers.map { |d| { id: d.id, name: d.name } }
   end
 
   def create
-    ride_attrs, addresses = Ride.extract_attrs_from_params(ride_params)
-    result_rides, success = Ride.build_linked_rides(ride_attrs, addresses)
+    ride_attrs, addresses, stops_data = Ride.extract_attrs_from_params(ride_params)
+    result_rides, success = Ride.build_linked_rides(ride_attrs, addresses, stops_data)
 
     if success
       @ride = result_rides[0]
@@ -61,6 +62,7 @@ class RidesController < ApplicationController
 
     # Mapping data for autocomplete
     gon.addresses = Address.all.map { |a| { name: a.name, street: a.street, city: a.city, phone: a.phone } }
+    gon.drivers = @drivers.map { |d| { id: d.id, name: d.name } }
 
     # Accessibility info is retrieved from the passenger
     @ride.wheelchair      = @ride.passenger&.wheelchair
@@ -72,7 +74,7 @@ class RidesController < ApplicationController
     @ride = Ride.find(params[:id])
     @drivers = Driver.order(:name)
 
-    ride_attrs, addresses = Ride.extract_attrs_from_params(ride_params)
+    ride_attrs, addresses, stops_data = Ride.extract_attrs_from_params(ride_params)
 
     # Destroy old ride chain
     all_rides = @ride.get_all_linked_rides
@@ -81,7 +83,7 @@ class RidesController < ApplicationController
     end
 
     # Rebuild new ride chain
-    result_rides, success = Ride.build_linked_rides(ride_attrs, addresses)
+    result_rides, success = Ride.build_linked_rides(ride_attrs, addresses, stops_data)
 
     if success
       @ride = result_rides[0]
@@ -128,6 +130,7 @@ class RidesController < ApplicationController
       :dest_address_id,
       :ride_type,
       addresses_attributes: [:name, :street, :city, :phone],
+      stops_attributes: [:driver_id, :van],
     )
   end
 end

--- a/app/javascript/add_stop.js
+++ b/app/javascript/add_stop.js
@@ -1,34 +1,73 @@
 document.addEventListener("turbo:load", function () {
   const addButton = document.getElementById("add-stop-button");
   const deleteButton = document.getElementById("delete-stop-button");
-  const grid = document.getElementById("address-grid");
+  const addressGrid = document.getElementById("address-grid");
+  const stopsContainer = document.getElementById("stops-container");
   const template = document.getElementById("destination-template");
 
-  let index = parseInt(grid.dataset.lastIndex, 10) + 1 || 2;
+  if (!addButton || !deleteButton || !stopsContainer || !template) {
+    return;
+  }
+
+  let index = parseInt(addressGrid?.dataset?.lastIndex, 10) + 1 || 2;
+
+  // Get drivers data from gon
+  let driversData = [];
+  if (typeof gon !== 'undefined' && gon.drivers) {
+    driversData = gon.drivers;
+  }
+
+  function populateDriverSelect(selectElement) {
+    // Clear existing options except the first one
+    selectElement.innerHTML = '<option value="">Select a Driver</option>';
+    
+    // Add driver options
+    driversData.forEach(function(driver) {
+      const option = document.createElement('option');
+      option.value = driver.id;
+      option.textContent = driver.name;
+      selectElement.appendChild(option);
+    });
+  }
 
   addButton.addEventListener("click", function () {
-    const html = template.innerHTML.replace(/__INDEX__/g, index);
-    const wrapper = document.createElement("div");
-    wrapper.innerHTML = html;
+    try {
+      const html = template.innerHTML.replace(/__INDEX__/g, index);
+      const wrapper = document.createElement("div");
+      wrapper.innerHTML = html;
 
-    const spacer = document.createElement("div");
-    spacer.className = "col-md-1";
+      if (wrapper.firstElementChild) {
+        // Populate driver dropdown in the new stop
+        const driverSelect = wrapper.querySelector('.driver-select');
+        if (driverSelect && driversData.length > 0) {
+          populateDriverSelect(driverSelect);
+        }
 
-    grid.appendChild(wrapper.firstElementChild);
-    grid.appendChild(spacer);
-
-    index += 1;
-    grid.dataset.lastIndex = index - 1; 
+        // Add the new stop card to the stops container
+        stopsContainer.appendChild(wrapper.firstElementChild);
+        
+        index += 1;
+        if (addressGrid) {
+          addressGrid.dataset.lastIndex = index - 1;
+        }
+      }
+    } catch (error) {
+      console.error("Error adding stop:", error);
+    }
   });
 
   deleteButton.addEventListener("click", function () {
-    // Must remove the spacer and the stop (2 elements)
-    // 4 turned out to be the min number to prevent issues with rides new and edit (don't know why)
-    if (grid.children.length > 4) {
-      grid.removeChild(grid.lastElementChild);
-      grid.removeChild(grid.lastElementChild);
-      index -= 1;
-      grid.dataset.lastIndex = index - 1;
+    try {
+      // Remove the last stop card if there's more than one stop
+      if (stopsContainer.children.length > 1) {
+        stopsContainer.removeChild(stopsContainer.lastElementChild);
+        index -= 1;
+        if (addressGrid) {
+          addressGrid.dataset.lastIndex = index - 1;
+        }
+      }
+    } catch (error) {
+      console.error("Error deleting stop:", error);
     }
   });
 });

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -74,6 +74,14 @@ class Ride < ApplicationRecord
     chain
   end
 
+  def all_drivers_names
+    get_all_linked_rides.map { |ride| ride.driver&.name }.compact.uniq.join(', ')
+  end
+
+  def all_vans_numbers
+    get_all_linked_rides.map { |ride| ride.van }.compact.uniq.join(', ')
+  end
+
   def self.extract_attrs_from_params(params)
     ride_attrs = params.except(:addresses_attributes, :stops_attributes).to_h
     addresses = params[:addresses_attributes]

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -75,11 +75,11 @@ class Ride < ApplicationRecord
   end
 
   def all_drivers_names
-    get_all_linked_rides.map { |ride| ride.driver.name }.uniq.join(', ')
+    get_all_linked_rides.map { |ride| ride.driver.name }.uniq.join(", ")
   end
 
   def all_vans_numbers
-    get_all_linked_rides.map { |ride| ride.van }.compact.uniq.join(', ')
+    get_all_linked_rides.filter_map { |ride| ride.van }.uniq.join(", ")
   end
 
   def self.extract_attrs_from_params(params)

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -25,7 +25,7 @@ class Ride < ApplicationRecord
     self.dest_address = Address.find_or_create_by!(normalized)
   end
 
-  def self.build_linked_rides(ride_attrs, addrs)
+  def self.build_linked_rides(ride_attrs, addrs, stops_data = [])
     created_rides = []
     prev_ride = nil
 
@@ -35,9 +35,17 @@ class Ride < ApplicationRecord
         origin = addrs[i]
         destination = addrs[i + 1]
 
+        # Create ride with base attributes
         ride = Ride.new(ride_attrs)
         ride.start_address_attributes = origin
         ride.dest_address_attributes = destination
+
+        # Override driver and van if provided in stops_data
+        if stops_data.present? && stops_data[i].present?
+          stop_data = stops_data[i]
+          ride.driver_id = stop_data[:driver_id] if stop_data[:driver_id].present?
+          ride.van = stop_data[:van] if stop_data[:van].present?
+        end
 
         if prev_ride
           prev_ride.next_ride = ride
@@ -67,14 +75,15 @@ class Ride < ApplicationRecord
   end
 
   def self.extract_attrs_from_params(params)
-    ride_attrs = params.except(:addresses_attributes).to_h
+    ride_attrs = params.except(:addresses_attributes, :stops_attributes).to_h
     addresses = params[:addresses_attributes]
+    stops_data = params[:stops_attributes] || []
 
     [:wheelchair, :disabled, :need_caregiver].each do |field|
       ride_attrs[field] = (ride_attrs[field] == "Yes") if ride_attrs.key?(field)
     end
 
-    [ride_attrs, addresses]
+    [ride_attrs, addresses, stops_data]
   end
 
   private

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -75,7 +75,7 @@ class Ride < ApplicationRecord
   end
 
   def all_drivers_names
-    get_all_linked_rides.map { |ride| ride.driver&.name }.compact.uniq.join(', ')
+    get_all_linked_rides.map { |ride| ride.driver.name }.uniq.join(', ')
   end
 
   def all_vans_numbers

--- a/app/views/drivers/_driver.html.erb
+++ b/app/views/drivers/_driver.html.erb
@@ -1,42 +1,161 @@
-<!-- Card Grid -->
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-  <% @drivers.each do |driver| %>
-    <div class="col">
+<!-- Active Drivers Section -->
+<div class="active-drivers-section">
+  <h3 class="mb-3">Active Drivers (<span id="active-count"><%= @active_drivers.count %></span>)</h3>
+  
+  <!-- Card Grid with more columns per row -->
+  <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-4">
+    <% @active_drivers.each do |driver| %>
+      <div class="col">
+        <div class="card driver-card">
+          <!-- Card header -->
+          <div class="driver-card-header">
+            <h5 class="card-title mb-0"><%= driver.name %></h5>
+            <small><%= driver.email.presence || "No email provided" %></small>
+          </div>
 
-      <div class="card driver-card">
+          <!-- Card body -->
+          <div class="driver-card-body">
+            <p class="mb-2">
+              <strong>Phone:</strong> <%= driver.phone.presence || "No phone number provided" %>
+            </p>
 
-        <!-- Card header -->
-        <div class="driver-card-header">
-          <h5 class="card-title mb-0"><%= driver.name %></h5>
-          <small><%= driver.email.presence || "No email provided" %></small>
-        </div>
+            <hr/>
+            <strong>Active:</strong> <span class="badge bg-success">Yes</span>
+          </div>
 
-        <!-- Card body -->
-        <div class="driver-card-body">
-          <p class="mb-2">
-            <strong>Phone:</strong> <%= driver.phone.presence || "No phone number provided" %>
-          </p>
-
-          <hr/>
-          <strong>Active:</strong> <%= driver.active? ? "Yes" : "No" %>
-        </div>
-
-        <!-- Card footer -->
-        <div class="driver-card-footer">
-          <% if current_user.dispatcher? || current_user.admin? %>
-            <%= link_to "Edit", edit_driver_path(driver), class: "btn btn-sm btn-outline-primary" %>
-          <% end %>
-          
-          <%= link_to "Today\'s Rides", today_driver_path(id: driver.id), class: "btn btn-primary", id: "today-btn" %>
-          
-          <% if current_user.dispatcher? || current_user.admin? %>
-            <%= link_to "Delete", driver, 
-                data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-                class: "btn btn-sm btn-outline-danger"
-            %>
-          <% end %>
+          <!-- Card footer -->
+          <div class="driver-card-footer">
+            <% if current_user.dispatcher? || current_user.admin? %>
+              <%= link_to "Edit", edit_driver_path(driver), class: "btn btn-sm btn-outline-primary" %>
+            <% end %>
+            
+            <%= link_to "Today\'s Rides", today_driver_path(id: driver.id), class: "btn btn-primary", id: "today-btn" %>
+            
+            <% if current_user.dispatcher? || current_user.admin? %>
+              <%= link_to "Delete", driver, 
+                  data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
+                  class: "btn btn-sm btn-outline-danger"
+              %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>
+
+<!-- Inactive Drivers Section -->
+<% if @inactive_drivers.any? %>
+  <div class="inactive-drivers-section mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h3 class="mb-0">Inactive Drivers (<span id="inactive-count"><%= @inactive_drivers.count %></span>)</h3>
+      <button type="button" class="btn btn-outline-secondary" id="toggle-inactive-btn">
+        <span id="toggle-text">Show Inactive</span>
+        <i class="fas fa-chevron-down" id="toggle-icon"></i>
+      </button>
+    </div>
+    
+    <!-- Card Grid for inactive drivers (initially hidden) -->
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-4" id="inactive-drivers-grid" style="display: none;">
+      <% @inactive_drivers.each do |driver| %>
+        <div class="col">
+          <div class="card driver-card inactive-driver-card">
+            <!-- Card header -->
+            <div class="driver-card-header">
+              <h5 class="card-title mb-0"><%= driver.name %></h5>
+              <small><%= driver.email.presence || "No email provided" %></small>
+            </div>
+
+            <!-- Card body -->
+            <div class="driver-card-body">
+              <p class="mb-2">
+                <strong>Phone:</strong> <%= driver.phone.presence || "No phone number provided" %>
+              </p>
+
+              <hr/>
+              <strong>Active:</strong> <span class="badge bg-secondary">No</span>
+            </div>
+
+            <!-- Card footer -->
+            <div class="driver-card-footer">
+              <% if current_user.dispatcher? || current_user.admin? %>
+                <%= link_to "Edit", edit_driver_path(driver), class: "btn btn-sm btn-outline-primary" %>
+              <% end %>
+              
+              <%= link_to "Today\'s Rides", today_driver_path(id: driver.id), class: "btn btn-primary", id: "today-btn" %>
+              
+              <% if current_user.dispatcher? || current_user.admin? %>
+                <%= link_to "Delete", driver, 
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
+                    class: "btn btn-sm btn-outline-danger"
+                %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<script>
+function initializeInactiveToggle() {
+  const toggleBtn = document.getElementById('toggle-inactive-btn');
+  const inactiveGrid = document.getElementById('inactive-drivers-grid');
+  const toggleText = document.getElementById('toggle-text');
+  const toggleIcon = document.getElementById('toggle-icon');
+  
+  if (toggleBtn && inactiveGrid) {
+    // Remove any existing event listeners to prevent duplicates
+    toggleBtn.replaceWith(toggleBtn.cloneNode(true));
+    const newToggleBtn = document.getElementById('toggle-inactive-btn');
+    const newToggleText = document.getElementById('toggle-text');
+    const newToggleIcon = document.getElementById('toggle-icon');
+    
+    newToggleBtn.addEventListener('click', function() {
+      if (inactiveGrid.style.display === 'none') {
+        inactiveGrid.style.display = 'flex';
+        newToggleText.textContent = 'Hide Inactive';
+        newToggleIcon.classList.remove('fa-chevron-down');
+        newToggleIcon.classList.add('fa-chevron-up');
+      } else {
+        inactiveGrid.style.display = 'none';
+        newToggleText.textContent = 'Show Inactive';
+        newToggleIcon.classList.remove('fa-chevron-up');
+        newToggleIcon.classList.add('fa-chevron-down');
+      }
+    });
+  }
+}
+
+// Handle both initial page load and Turbo navigation
+document.addEventListener('DOMContentLoaded', initializeInactiveToggle);
+document.addEventListener('turbo:load', initializeInactiveToggle);
+</script>
+
+<style>
+.inactive-driver-card {
+  opacity: 0.8;
+}
+
+.inactive-driver-card:hover {
+  opacity: 1;
+}
+
+.badge {
+  font-size: 0.75em;
+}
+
+#toggle-inactive-btn {
+  transition: all 0.3s ease;
+}
+
+#toggle-inactive-btn:hover {
+  transform: translateY(-1px);
+}
+
+#toggle-icon {
+  transition: transform 0.3s ease;
+  margin-left: 5px;
+}
+</style>

--- a/app/views/drivers/index.html.erb
+++ b/app/views/drivers/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container my-4">
+<div class="container-fluid my-4">
   <h1 class="mb-4">Drivers</h1>
 
   <!-- UI Buttons -->

--- a/app/views/rides/_ride.html.erb
+++ b/app/views/rides/_ride.html.erb
@@ -9,8 +9,8 @@
               <th class="border-0"></th> <!-- Info Button -->
               <th class="border-0"></th> <!-- Delete Button -->
               <th class="border-0 text-filter">Date</th>
-              <th class="border-0 text-filter">Driver</th>
-              <th class="border-0 text-filter">Van</th>
+              <th class="border-0 text-filter">Driver(s)</th>
+              <th class="border-0 text-filter">Van(s)</th>
               <th class="border-0 text-filter">Last Name</th>
               <th class="border-0 text-filter">First Name</th>
               <th class="border-0 text-filter">Stops Info</th>
@@ -53,8 +53,8 @@
                 <td data-order="<%= ride.date.strftime('%Y-%m-%d') %>">
                   <%= ride.date.strftime('%m/%d/%Y') %>
                 </td>
-                <td><%= ride.driver&.name || 'N/A' %></td>
-                <td><%= ride.van || 'N/A' %></td>
+                <td><%= ride.all_drivers_names.present? ? ride.all_drivers_names : 'N/A' %></td>
+                <td><%= ride.all_vans_numbers.present? ? ride.all_vans_numbers : 'N/A' %></td>
                 <% full_name = ride.passenger&.name.to_s.strip %>
                 <% name_parts = full_name.split(' ') %>
                 <% last_name = name_parts.length > 1 ? name_parts.last : nil %>

--- a/app/views/rides/_stop_fields.html.erb
+++ b/app/views/rides/_stop_fields.html.erb
@@ -1,46 +1,92 @@
-<div class="col-md-5">
-    <h5 class="fw-bold text-success text-center">Stop <%= index %></h5>
-        <div class="mb-3">
-            <label class="form-label" for="ride_dest_address_attributes_<%= index %>_name">Address Name</label>
-            <input type="text"
-                name="ride[addresses_attributes][][name]"
-                value="<%= address&.name %>"
-                class="form-control dest-autocomplete"
-                id="ride_dest_address_attributes_<%= index %>_name"
-                autocomplete="ride-name">
+<div class="col-md-12 mb-4">
+    <div class="card">
+        <div class="card-header bg-success text-white">
+            <h6 class="mb-0 fw-bold text-center">Stop <%= index %></h6>
         </div>
-  
-        <div class="mb-3">
-            <label class="form-label" for="ride_dest_address_attributes_<%= index %>_street">Street</label>
-            <span class="text-danger">*</span>
-            <input type="text"
-                name="ride[addresses_attributes][][street]"
-                value="<%= address&.street %>"
-                class="form-control dest-autocomplete"
-                id="ride_dest_address_attributes_<%= index %>_street"
-                required
-                autocomplete="ride-address">
-        </div>
+        <div class="card-body">
+            <div class="row">
+                <!-- Address Fields -->
+                <div class="col-md-6">
+                    <h6 class="fw-bold text-muted mb-3">Address</h6>
+                    <div class="mb-3">
+                        <label class="form-label" for="ride_dest_address_attributes_<%= index %>_name">Address Name</label>
+                        <input type="text"
+                            name="ride[addresses_attributes][][name]"
+                            value="<%= address&.name %>"
+                            class="form-control dest-autocomplete"
+                            id="ride_dest_address_attributes_<%= index %>_name"
+                            autocomplete="ride-name">
+                    </div>
+              
+                    <div class="mb-3">
+                        <label class="form-label" for="ride_dest_address_attributes_<%= index %>_street">Street</label>
+                        <span class="text-danger">*</span>
+                        <input type="text"
+                            name="ride[addresses_attributes][][street]"
+                            value="<%= address&.street %>"
+                            class="form-control dest-autocomplete"
+                            id="ride_dest_address_attributes_<%= index %>_street"
+                            required
+                            autocomplete="ride-address">
+                    </div>
 
-        <div class="mb-3">
-            <label class="form-label" for="ride_dest_address_attributes_<%= index %>_city">City</label>
-            <span class="text-danger">*</span>
-            <input type="text"
-                name="ride[addresses_attributes][][city]"
-                value="<%= address&.city %>"
-                class="form-control"
-                id="ride_dest_address_attributes_<%= index %>_city"
-                required
-                autocomplete="ride-city">
-        </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="ride_dest_address_attributes_<%= index %>_city">City</label>
+                        <span class="text-danger">*</span>
+                        <input type="text"
+                            name="ride[addresses_attributes][][city]"
+                            value="<%= address&.city %>"
+                            class="form-control"
+                            id="ride_dest_address_attributes_<%= index %>_city"
+                            required
+                            autocomplete="ride-city">
+                    </div>
 
-        <div class="mb-3">
-            <label class="form-label" for="ride_dest_address_attributes_<%= index %>_phone">Phone</label>
-            <input type="text"
-                name="ride[addresses_attributes][][phone]"
-                value="<%= address&.phone %>"
-                class="form-control"
-                id="ride_dest_address_attributes_<%= index %>_phone"
-                autocomplete="ride-phone">
+                    <div class="mb-3">
+                        <label class="form-label" for="ride_dest_address_attributes_<%= index %>_phone">Phone</label>
+                        <input type="text"
+                            name="ride[addresses_attributes][][phone]"
+                            value="<%= address&.phone %>"
+                            class="form-control"
+                            id="ride_dest_address_attributes_<%= index %>_phone"
+                            autocomplete="ride-phone">
+                    </div>
+                </div>
+
+                <!-- Driver and Van Fields -->
+                <div class="col-md-6">
+                    <h6 class="fw-bold text-muted mb-3">Driver & Van</h6>
+                    <div class="mb-3">
+                        <label class="form-label" for="stop_<%= index %>_driver_id">Driver</label>
+                        <span class="text-danger">*</span>
+                        <% if defined?(drivers) && drivers %>
+                            <select name="ride[stops_attributes][][driver_id]"
+                                    class="form-select"
+                                    id="stop_<%= index %>_driver_id"
+                                    required>
+                                <option value="">Select a Driver</option>
+                                <% drivers.each do |driver| %>
+                                    <option value="<%= driver.id %>" 
+                                            <%= 'selected' if defined?(selected_driver_id) && selected_driver_id == driver.id %>>
+                                        <%= driver.name %>
+                                    </option>
+                                <% end %>
+                            </select>
+                        <% else %>
+                            <input type="text" class="form-control" value="Drivers not available" disabled>
+                        <% end %>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="stop_<%= index %>_van">Van</label>
+                        <input type="number"
+                               name="ride[stops_attributes][][van]"
+                               value="<%= defined?(selected_van) ? selected_van : '' %>"
+                               class="form-control"
+                               id="stop_<%= index %>_van">
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
+</div>

--- a/app/views/rides/edit.html.erb
+++ b/app/views/rides/edit.html.erb
@@ -1,6 +1,6 @@
 <!-- app/views/rides/edit.html.erb -->
 <div class="row justify-content-center">
-  <div class="col-md-10">
+  <div class="col-md-12">
     <h1 class="mb-4 text-center">Edit Ride</h1>
 
     <!-- Display error messages -->
@@ -18,295 +18,366 @@
     <%= form_with(model: @ride, local: true) do |f| %>
       <div class="row">
         <!-- Left Column (Ride Details) -->
-        <div class="col-md-6 border-end">
-          <h5 class="fw-bold text-success">Ride Details</h5>
-
-          <div class="mb-3">
-            <%= f.label :date, "Date" %> <span class="text-danger">*</span>
-            <%= f.text_field :date, type: "date", value: f.object.date&.strftime("%Y-%m-%d"), class: "form-control", required: true %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :driver_id, "Driver" %> <span class="text-danger">*</span>
-            <%= f.select :driver_id,
-                          options_from_collection_for_select(@drivers, :id, :name, @ride.driver_id),
-                          { prompt: "Select a Driver" },
-                          { class: "form-select" } %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :van, "Van" %>
-            <%= f.number_field :van, class: "form-control" %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :hours, "Hours" %>
-            <%= f.number_field :hours, step: 0.1, class: "form-control" %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :amount_paid, "Amount Paid" %>
-            <%= f.number_field :amount_paid, step: 0.01, class: "form-control", id: "amount_paid_field" %>
-
-            <!-- Quick Amount Selection Buttons -->
-            <div class="mt-2 mb-3">
-              <label class="form-label text-muted small">Quick Select:</label>
-              <div class="btn-group">
-                <% [0, 5, 10, 20].each do |amount| %>
-                  <button type="button" class="btn btn-sm btn-outline-secondary fare-quick-select" 
-                          data-amount="<%= amount %>">
-                    $<%= amount %>
-                  </button>
-                <% end %>
-              </div>
-              <script>
-                document.addEventListener('turbo:load', function() {
-                  const amountField = document.getElementById('amount_paid_field');
-                  const quickButtons = document.querySelectorAll('.fare-quick-select');
-
-                  quickButtons.forEach(button => {
-                    button.addEventListener('click', function() {
-                      amountField.value = this.getAttribute('data-amount');
-                    });
-                  });
-                });
-              </script>
-            </div>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :notes_to_driver, "Notes to Driver" %>
-            <%= f.text_area :notes_to_driver, class: "form-control", rows: 3 %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :notes, "Notes" %>
-            <%= f.text_area :notes, class: "form-control", rows: 3 %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :ride_type, "Ride Type:" %>
-            <%= f.text_field :ride_type, class: "form-control" %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :fare_type, "Fare Type:" %>
-            <%= f.text_field :fare_type, class: "form-control" %>
-          </div>
-
-          <div class="mb-3">
-             <%= f.label :status, "Status" %> <span class="text-danger">*</span>
-             <%= f.select :status,
-                          [["Requested"], ['Pending'], ['Scheduled'], ['Confirmed'], ['Email sent'], ["Waitlisted"], ['Cancelled']],
-                          {},
-                          class: "form-select" %>
-          </div>
-        </div>
-
-        <!-- Right Column (Passenger + Addresses) -->
-        <div class="col-md-6">
-          <h5 class="fw-bold text-success">
-            Passenger Details
-            <% if @ride.passenger && @ride.passenger.rides.count <= 1 %>
-              <span class="badge bg-warning text-dark" data-bs-toggle="tooltip" data-bs-placement="top" 
-                    title="This is a new passenger with no previous ride history">
-                First Time Rider <i class="bi bi-exclamation-triangle"></i>
-              </span>
-            <% end %>
-          </h5>
-
-          <%= f.hidden_field :passenger_id, class: "form-control" %>
-          <%= f.hidden_field :wheelchair, class: "form-control", value: @ride.wheelchair ? "Yes" : "No" %>
-          <%= f.hidden_field :disabled, class: "form-control", value: @ride.disabled ? "Yes" : "No" %>
-          <%= f.hidden_field :need_caregiver, class: "form-control", value: @ride.need_caregiver ? "Yes" : "No" %>
-
-          <div class="mb-3">
-            <%= f.label :passenger_name, "Passenger Name" %>
-            <input type="text" 
-                   class="form-control bg-secondary text-white opacity-50"
-                   style="cursor: not-allowed"
-                   value="<%= @ride.passenger&.name || 'N/A' %>" 
-                   readonly>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :passenger_home_address, "Home Address" %>
-            <input type="text" 
-                   class="form-control bg-secondary text-white opacity-50"
-                   style="cursor: not-allowed"
-                   value="<%= @ride.passenger&.full_address || 'N/A' %>"
-                   readonly>
-          </div>
-
-          <!-- NEW: Accessibility Information -->
-          <div class="card mb-3">
-            <div class="card-header bg-success text-white py-2">
-              <h6 class="mb-0">Accessibility Needs</h6>
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-primary text-white">
+              <h5 class="mb-0 fw-bold">Ride Details</h5>
             </div>
             <div class="card-body">
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="form-check mb-2">
-                    <% if @ride.passenger&.wheelchair %>
-                      <input type="checkbox" 
-                             class="form-check-input bg-primary"
-                             checked
-                             disabled
-                             id="wheelchair_display">
-                      <label class="form-check-label fw-bold" for="wheelchair_display">Requires Wheelchair</label>
-                    <% else %>
-                      <input type="checkbox" 
-                             class="form-check-input bg-secondary opacity-50"
-                             disabled
-                             id="wheelchair_display">
-                      <label class="form-check-label" for="wheelchair_display">Requires Wheelchair</label>
-                    <% end %>
-                  </div>
+              <div class="mb-3">
+                <%= f.label :date, "Date" %> <span class="text-danger">*</span>
+                <%= f.text_field :date, type: "date", value: f.object.date&.strftime("%Y-%m-%d"), class: "form-control", required: true %>
+              </div>
 
-                  <div class="form-check mb-2">
-                    <% if @ride.passenger&.disabled %>
-                      <input type="checkbox" 
-                             class="form-check-input bg-primary"
-                             checked
-                             disabled
-                             id="disabled_display">
-                      <label class="form-check-label fw-bold" for="disabled_display">Has Disability</label>
-                    <% else %>
-                      <input type="checkbox" 
-                             class="form-check-input bg-secondary opacity-50"
-                             disabled
-                             id="disabled_display">
-                      <label class="form-check-label" for="disabled_display">Has Disability</label>
-                    <% end %>
-                  </div>
-                </div>
+              <div class="mb-3">
+                <%= f.label :hours, "Hours" %>
+                <%= f.number_field :hours, step: 0.1, class: "form-control" %>
+              </div>
 
-                <div class="col-md-6">
-                  <div class="form-check mb-2">
-                    <% if @ride.passenger&.need_caregiver %>
-                      <input type="checkbox" 
-                             class="form-check-input bg-primary"
-                             checked
-                             disabled
-                             id="need_caregiver_display">
-                      <label class="form-check-label fw-bold" for="need_caregiver_display">Needs Caregiver</label>
-                    <% else %>
-                      <input type="checkbox" 
-                             class="form-check-input bg-secondary opacity-50"
-                             disabled
-                             id="need_caregiver_display">
-                      <label class="form-check-label" for="need_caregiver_display">Needs Caregiver</label>
+              <div class="mb-3">
+                <%= f.label :amount_paid, "Amount Paid" %>
+                <%= f.number_field :amount_paid, step: 0.01, class: "form-control", id: "amount_paid_field" %>
+
+                <!-- Quick Amount Selection Buttons -->
+                <div class="mt-2 mb-3">
+                  <label class="form-label text-muted small">Quick Select:</label>
+                  <div class="btn-group">
+                    <% [0, 5, 10, 20].each do |amount| %>
+                      <button type="button" class="btn btn-sm btn-outline-secondary fare-quick-select" 
+                              data-amount="<%= amount %>">
+                        $<%= amount %>
+                      </button>
                     <% end %>
                   </div>
+                  <script>
+                    document.addEventListener('turbo:load', function() {
+                      const amountField = document.getElementById('amount_paid_field');
+                      const quickButtons = document.querySelectorAll('.fare-quick-select');
+
+                      quickButtons.forEach(button => {
+                        button.addEventListener('click', function() {
+                          amountField.value = this.getAttribute('data-amount');
+                        });
+                      });
+                    });
+                  </script>
                 </div>
               </div>
 
-              <!-- Passenger Notes -->
-              <div class="mt-3">
-                <label class="form-label">Accessibility Notes:</label>
-                <textarea class="form-control bg-light" 
-                          readonly
-                          rows="2"><%= @ride.passenger&.notes || 'No notes available' %></textarea>
-
+              <div class="mb-3">
+                <%= f.label :notes_to_driver, "Notes to Driver" %>
+                <%= f.text_area :notes_to_driver, class: "form-control", rows: 3 %>
               </div>
 
-              <!-- Passenger Phone -->
-              <div class="mt-3">
-                <label class="form-label">Phone Number:</label>
+              <div class="mb-3">
+                <%= f.label :notes, "Notes (to dispatcher)" %>
+                <%= f.text_area :notes, class: "form-control", rows: 3 %>
+              </div>
+
+              <div class="mb-3">
+                <%= f.label :ride_type, "Ride Type" %>
+                <%= f.text_field :ride_type, class: "form-control" %>
+              </div>
+
+              <div class="mb-3">
+                <%= f.label :fare_type, "Fare Type" %>
+                <%= f.text_field :fare_type, class: "form-control" %>
+              </div>
+
+              <div class="mb-3">
+                <%= f.label :status, "Status" %> <span class="text-danger">*</span>
+                <%= f.select :status,
+                             [["Requested"], ['Pending'], ['Scheduled'], ['Confirmed'], ['Email sent'], ["Waitlisted"], ['Cancelled']],
+                             {},
+                             class: "form-select" %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Middle Column (Passenger Details) -->
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-info text-white">
+              <h5 class="mb-0 fw-bold">
+                Passenger Details
+                <% if @ride.passenger && @ride.passenger.rides.count <= 1 %>
+                  <span class="badge bg-warning text-dark" data-bs-toggle="tooltip" data-bs-placement="top" 
+                        title="This is a new passenger with no previous ride history">
+                    First Time Rider <i class="bi bi-exclamation-triangle"></i>
+                  </span>
+                <% end %>
+              </h5>
+            </div>
+            <div class="card-body">
+              <%= f.hidden_field :passenger_id, class: "form-control" %>
+              <%= f.hidden_field :wheelchair, class: "form-control", value: @ride.wheelchair ? "Yes" : "No" %>
+              <%= f.hidden_field :disabled, class: "form-control", value: @ride.disabled ? "Yes" : "No" %>
+              <%= f.hidden_field :need_caregiver, class: "form-control", value: @ride.need_caregiver ? "Yes" : "No" %>
+
+              <div class="mb-3">
+                <%= f.label :passenger_name, "Passenger Name" %>
                 <input type="text" 
-                       class="form-control bg-light" 
-                       readonly
-                       value="<%= @ride.passenger&.phone || 'No phone available' %>">
+                       class="form-control bg-secondary text-white opacity-50"
+                       style="cursor: not-allowed"
+                       value="<%= @ride.passenger&.name || 'N/A' %>" 
+                       readonly>
+              </div>
+
+              <div class="mb-3">
+                <%= f.label :passenger_home_address, "Home Address" %>
+                <input type="text" 
+                       class="form-control bg-secondary text-white opacity-50"
+                       style="cursor: not-allowed"
+                       value="<%= @ride.passenger&.full_address || 'N/A' %>"
+                       readonly>
+              </div>
+
+              <!-- Accessibility Information -->
+              <div class="card mb-3">
+                <div class="card-header bg-success text-white py-2">
+                  <h6 class="mb-0">Accessibility Needs</h6>
+                </div>
+                <div class="card-body">
+                  <div class="row">
+                    <div class="col-md-6">
+                      <div class="form-check mb-2">
+                        <% if @ride.passenger&.wheelchair %>
+                          <input type="checkbox" 
+                                 class="form-check-input bg-primary"
+                                 checked
+                                 disabled
+                                 id="wheelchair_display">
+                          <label class="form-check-label fw-bold" for="wheelchair_display">Wheelchair</label>
+                        <% else %>
+                          <input type="checkbox" 
+                                 class="form-check-input bg-secondary opacity-50"
+                                 disabled
+                                 id="wheelchair_display">
+                          <label class="form-check-label" for="wheelchair_display">Wheelchair</label>
+                        <% end %>
+                      </div>
+
+                      <div class="form-check mb-2">
+                        <% if @ride.passenger&.disabled %>
+                          <input type="checkbox" 
+                                 class="form-check-input bg-primary"
+                                 checked
+                                 disabled
+                                 id="disabled_display">
+                          <label class="form-check-label fw-bold" for="disabled_display">Disability</label>
+                        <% else %>
+                          <input type="checkbox" 
+                                 class="form-check-input bg-secondary opacity-50"
+                                 disabled
+                                 id="disabled_display">
+                          <label class="form-check-label" for="disabled_display">Disability</label>
+                        <% end %>
+                      </div>
+                    </div>
+
+                    <div class="col-md-6">
+                      <div class="form-check mb-2">
+                        <% if @ride.passenger&.need_caregiver %>
+                          <input type="checkbox" 
+                                 class="form-check-input bg-primary"
+                                 checked
+                                 disabled
+                                 id="need_caregiver_display">
+                          <label class="form-check-label fw-bold" for="need_caregiver_display">Caregiver</label>
+                        <% else %>
+                          <input type="checkbox" 
+                                 class="form-check-input bg-secondary opacity-50"
+                                 disabled
+                                 id="need_caregiver_display">
+                          <label class="form-check-label" for="need_caregiver_display">Caregiver</label>
+                        <% end %>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Passenger Notes -->
+                  <div class="mt-3">
+                    <label class="form-label">Accessibility Notes:</label>
+                    <textarea class="form-control bg-light" 
+                              readonly
+                              rows="2"><%= @ride.passenger&.notes || 'No notes available' %></textarea>
+                  </div>
+
+                  <!-- Passenger Phone -->
+                  <div class="mt-3">
+                    <label class="form-label">Phone Number:</label>
+                    <input type="text" 
+                           class="form-control bg-light" 
+                           readonly
+                           value="<%= @ride.passenger&.phone || 'No phone available' %>">
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-          <!-- END: Accessibility Information -->
-
-          <!-- Address Container with Justify Content Row -->
-          <div class="row g-4" id="address-grid" data-last-index="<%= @all_rides.size %>">
-            <!-- Origin Address -->
-            <div class="col-md-5">
-              <h5 class="fw-bold text-success text-center">Origin</h5>
-
-              <div class="mb-3">
-                <label class="form-label" for="ride_start_address_attributes_name">Address Name</label>
-                <input type="text"
-                       value="<%= @ride.start_address&.name %>"
-                       name="ride[addresses_attributes][][name]"
-                       class="form-control"
-                       id="ride_start_address_attributes_name"
-                       autocomplete="ride-name">
-              </div>
-
-              <div class="mb-3">
-                <label class="form-label" for="ride_start_address_attributes_street">Street</label>
-                <span class="text-danger">*</span>
-                <input type="text"
-                       value="<%= @ride.start_address&.street %>"
-                       name="ride[addresses_attributes][][street]"
-                       class="form-control"
-                       id="ride_start_address_attributes_street"
-                       required
-                       autocomplete="ride-address">
-              </div>
-
-              <div class="mb-3">
-                <label class="form-label" for="ride_start_address_attributes_city">City</label>
-                <span class="text-danger">*</span>
-                <input type="text"
-                       value="<%= @ride.start_address&.city %>"
-                       name="ride[addresses_attributes][][city]"
-                       class="form-control"
-                       id="ride_start_address_attributes_city"
-                       required
-                       autocomplete="ride-city">
-              </div>
-
-              <div class="mb-3">
-                <label class="form-label" for="ride_start_address_attributes_phone">Phone</label>
-                <input type="text"
-                       value="<%= @ride.start_address&.phone %>"
-                       name="ride[addresses_attributes][][phone]"
-                       class="form-control"
-                       id="ride_start_address_attributes_phone"
-                       autocomplete="ride-phone">
-              </div>
-            </div>
-
-            <!-- Spacer -->
-            <div class="col-md-1" id="col-space"></div>
-
-            <!-- Destination Address (Existing Stops) -->
-            <% @all_rides.each_with_index do |ride, index| %>
-              <%= render partial: "stop_fields", locals: { address: ride.dest_address, index: index + 1 } %>
-            <% end %>
-            
-            <!-- Spacer -->
-            <div class="col-md-1" id="col-space"></div>
-          </div>
-
-          <!-- Add/Delete Stop Buttons -->
-          <div class="text-center mt-4">
-            <div class="mt-3">
-              <button type="button" class="btn btn-success mt-3" id="add-stop-button">Add Stop</button>
-              <button type="button" class="btn btn-danger mt-3" id="delete-stop-button">Delete Stop</button>
-            </div>
-          </div>
-
-          <!-- Hidden Template for Additional Destination -->
-          <template id="destination-template">
-            <%= render partial: "stop_fields", locals: { index: "__INDEX__", address: nil } %>
-          </template>
         </div>
 
-        <!-- Action Buttons -->
-        <div class="text-center mt-4">
-          <%= f.submit "Update", class: "btn btn-primary" %>
-          <%= link_to "All Rides", rides_path, class: "btn btn-secondary" %>
-          <%= link_to "All Shifts", shifts_path, class: "btn btn-secondary" %>
+        <!-- Right Column (Stops Detail) -->
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-warning text-dark">
+              <h5 class="mb-0 fw-bold">Stops Detail</h5>
+            </div>
+            <div class="card-body" id="address-grid" data-last-index="<%= @all_rides.size %>">
+              <!-- Origin Address -->
+              <div class="card mb-4">
+                <div class="card-header bg-secondary text-white">
+                  <h6 class="mb-0 fw-bold text-center">Origin</h6>
+                </div>
+                <div class="card-body">
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_name">Address Name</label>
+                    <input type="text"
+                           value="<%= @ride.start_address&.name %>"
+                           name="ride[addresses_attributes][][name]"
+                           class="form-control"
+                           id="ride_start_address_attributes_name"
+                           autocomplete="ride-name">
+                  </div>
+
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_street">Street</label>
+                    <span class="text-danger">*</span>
+                    <input type="text"
+                           value="<%= @ride.start_address&.street %>"
+                           name="ride[addresses_attributes][][street]"
+                           class="form-control"
+                           id="ride_start_address_attributes_street"
+                           required
+                           autocomplete="ride-address">
+                  </div>
+
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_city">City</label>
+                    <span class="text-danger">*</span>
+                    <input type="text"
+                           value="<%= @ride.start_address&.city %>"
+                           name="ride[addresses_attributes][][city]"
+                           class="form-control"
+                           id="ride_start_address_attributes_city"
+                           required
+                           autocomplete="ride-city">
+                  </div>
+
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_phone">Phone</label>
+                    <input type="text"
+                           value="<%= @ride.start_address&.phone %>"
+                           name="ride[addresses_attributes][][phone]"
+                           class="form-control"
+                           id="ride_start_address_attributes_phone"
+                           autocomplete="ride-phone">
+                  </div>
+                </div>
+              </div>
+
+              <!-- Stops Container -->
+              <div id="stops-container">
+                <!-- Existing Stops -->
+                <% @all_rides.each_with_index do |ride, index| %>
+                  <%= render partial: "stop_fields", locals: { 
+                    address: ride.dest_address, 
+                    index: index + 1, 
+                    drivers: @drivers,
+                    selected_driver_id: ride.driver_id,
+                    selected_van: ride.van
+                  } %>
+                <% end %>
+              </div>
+
+              <!-- Add/Delete Stop Buttons -->
+              <div class="text-center mt-4">
+                <button type="button" class="btn btn-success" id="add-stop-button">Add Stop</button>
+                <button type="button" class="btn btn-danger" id="delete-stop-button">Delete Stop</button>
+              </div>
+
+              <!-- Hidden Template for Additional Destination -->
+              <template id="destination-template">
+                <div class="col-md-12 mb-4">
+                  <div class="card">
+                    <div class="card-header bg-success text-white">
+                      <h6 class="mb-0 fw-bold text-center">Stop __INDEX__</h6>
+                    </div>
+                    <div class="card-body">
+                      <div class="row">
+                        <!-- Address Fields -->
+                        <div class="col-md-6">
+                          <h6 class="fw-bold text-muted mb-3">Address</h6>
+                                                     <div class="mb-3">
+                             <label class="form-label">Address Name</label>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][name]" 
+                                    class="form-control dest-autocomplete" 
+                                    id="ride_dest_address_attributes___INDEX___name"
+                                    autocomplete="ride-name">
+                           </div>
+                           <div class="mb-3">
+                             <label class="form-label">Street</label>
+                             <span class="text-danger">*</span>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][street]" 
+                                    class="form-control dest-autocomplete" 
+                                    id="ride_dest_address_attributes___INDEX___street"
+                                    required 
+                                    autocomplete="ride-address">
+                           </div>
+                           <div class="mb-3">
+                             <label class="form-label">City</label>
+                             <span class="text-danger">*</span>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][city]" 
+                                    class="form-control"
+                                    id="ride_dest_address_attributes___INDEX___city" 
+                                    required 
+                                    autocomplete="ride-city">
+                           </div>
+                           <div class="mb-3">
+                             <label class="form-label">Phone</label>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][phone]" 
+                                    class="form-control"
+                                    id="ride_dest_address_attributes___INDEX___phone" 
+                                    autocomplete="ride-phone">
+                           </div>
+                        </div>
+                        <!-- Driver and Van Fields -->
+                        <div class="col-md-6">
+                          <h6 class="fw-bold text-muted mb-3">Driver & Van</h6>
+                          <div class="mb-3">
+                            <label class="form-label">Driver</label>
+                            <span class="text-danger">*</span>
+                            <select name="ride[stops_attributes][][driver_id]" class="form-select driver-select" required>
+                              <option value="">Select a Driver</option>
+                            </select>
+                          </div>
+                          <div class="mb-3">
+                            <label class="form-label">Van</label>
+                            <input type="number" name="ride[stops_attributes][][van]" class="form-control">
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
         </div>
-        <% end %>
       </div>
+
+      <!-- Action Buttons -->
+      <div class="text-center mt-4">
+        <%= f.submit "Update", class: "btn btn-primary" %>
+        <%= link_to "All Rides", rides_path, class: "btn btn-secondary" %>
+        <%= link_to "All Shifts", shifts_path, class: "btn btn-secondary" %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/rides/new.html.erb
+++ b/app/views/rides/new.html.erb
@@ -1,260 +1,321 @@
 <%= javascript_importmap_tags %>
 
-
 <!-- app/views/rides/new.html.erb -->
- <div class="row justify-content-center">
-   <div class="col-md-10">
-     <h1 class="mb-4 text-center">New Ride </h1>
+<div class="row justify-content-center">
+  <div class="col-md-12">
+    <h1 class="mb-4 text-center">New Ride</h1>
 
+    <!-- Display error messages -->
+    <% if @ride.errors.any? %>
+      <div class="alert alert-danger">
+        <h4><%= pluralize(@ride.errors.count, "error") %> prohibited this ride from being saved:</h4>
+        <ul>
+          <% @ride.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
-     <!-- Display error messages -->
-     <% if @ride.errors.any? %>
-       <div class="alert alert-danger">
-         <h4><%= pluralize(@ride.errors.count, "error") %> prohibited this ride from being saved:</h4>
-         <ul>
-           <% @ride.errors.full_messages.each do |message| %>
-             <li><%= message %></li>
-           <% end %>
-         </ul>
-       </div>
-     <% end %>
+    <!-- Display success notice -->
+    <% if flash[:notice].present? %>
+      <div class="alert alert-success">
+        <%= flash[:notice] %>
+      </div>
+    <% end %>
 
+    <%= form_with(model: @ride, local: true) do |f| %>
+      <div class="row">
+        <!-- Left Column (Ride Details) -->
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-primary text-white">
+              <h5 class="mb-0 fw-bold">Ride Details</h5>
+            </div>
+            <div class="card-body">
+              <div class="mb-3">
+                <%= f.label :date, "Date" %> <span class="text-danger">*</span>
+                <%= f.text_field :date, type: "date", value: f.object.date&.strftime("%m/%d/%Y"), class: "form-control", required: true %>
+              </div>
 
-     <!-- Display success notice -->
-     <% if flash[:notice].present? %>
-       <div class="alert alert-success">
-         <%= flash[:notice] %>
-       </div>
-     <% end %>
+              <div class="mb-3">
+                <%= f.label :notes_to_driver, "Notes to Driver" %>
+                <%= f.text_area :notes_to_driver, class: "form-control", rows: 3 %>
+              </div>
 
+              <div class="mb-3">
+                <%= f.label :notes, "Notes (to dispatcher)" %>
+                <%= f.text_area :notes, class: "form-control", rows: 3 %>
+              </div>
 
-     <%= form_with(model: @ride, local: true) do |f| %>
-       <div class="row">
-         <!-- Left Column (Ride Details) -->
-         <div class="col-md-6 border-end">
-           <h5 class="fw-bold text-success">Ride Details</h5>
+              <div class="mb-3">
+                <%= f.label :ride_type, "Ride Type" %>
+                <%= f.text_field :ride_type, class: "form-control" %>
+              </div>
 
-           <div class="mb-3">
-             <%= f.label :date, "Date" %> <span class="text-danger">*</span>
-             <%= f.text_field :date, type: "date", value: f.object.date&.strftime("%m/%d/%Y"), class: "form-control", required: true %>
-           </div>
+              <div class="mb-3">
+                <%= f.label :fare_type, "Fare Type" %>
+                <%= f.text_field :fare_type, class: "form-control" %>
+              </div>
 
-           <div class="mb-3">
-             <%= f.label :driver_id, "Driver" %> <span class="text-danger">*</span>
-             <%= f.select :driver_id,
-                          options_from_collection_for_select(@drivers, :id, :name, @ride.driver_id),
-                          { prompt: "Select a Driver" },
-                          { class: "form-select", required: true  }%>
-           </div>
+              <div class="mb-3">
+                <%= f.label :status, "Status" %> <span class="text-danger">*</span>
+                <%= f.select :status,
+                             [["Requested"], ['Pending'], ['Scheduled'], ['Confirmed'], ['Email sent'], ["Waitlisted"], ['Cancelled']],
+                             {},
+                             class: "form-select", required: true %>
+              </div>
+            </div>
+          </div>
+        </div>
 
-           <div class="mb-3">
-             <%= f.label :van, "Van" %>
-             <%= f.number_field :van, class: "form-control" %>
-           </div>
-
-           <div class="mb-3">
-             <%= f.label :notes_to_driver, "Notes to Driver" %>
-             <%= f.text_area :notes_to_driver, class: "form-control", rows: 3 %>
-           </div>
-
-            <div class="mb-3">
-             <%= f.label :notes, "Notes" %>
-             <%= f.text_area :notes, class: "form-control", rows: 3 %>
-           </div>
-
-           <div class="mb-3">
-            <%= f.label :ride_type, "Ride Type:" %>
-            <%= f.text_field :ride_type, class: "form-control", rows: 3 %>
-           </div>
-
-           <div class="mb-3">
-            <%= f.label :fare_type, "Fare Type:" %>
-            <%= f.text_field :fare_type, class: "form-control", rows: 3 %>
-           </div>
-
-           <div class="mb-3">
-             <%= f.label :status, "Status" %> <span class="text-danger">*</span>
-             <%= f.select :status,
-                          [["Requested"], ['Pending'], ['Scheduled'], ['Confirmed'], ['Email sent'], ["Waitlisted"], ['Cancelled']],
-                          {},
-                          class: "form-select", required: true %>
-           </div>
-         </div>
-
-
-         <!-- Right Column (Passenger + Addresses) -->
-         <div class="col-md-6">
-           <h5 class="fw-bold text-success">
-             Passenger Details
-           </h5>
-
-           <div class="mb-3">
-             <%= f.label :passenger_name, "Passenger" %> <span class="text-danger">*</span>
-             <div class="input-group">
-               <%= f.text_field :passenger_name, class: "form-control", required: true %>
-               <%= link_to new_passenger_path(return_url: request.fullpath), class: "btn btn-success" do %>
-                 <i class="bi bi-person-plus"></i> Create New Passenger
-               <% end %>
-             </div>
-             <small class="form-text text-muted">Type to search existing passengers or click "Create New Passenger" to create one</small>
-           </div>
-
-           <%= f.hidden_field :passenger_id, class: "form-control" %>
-           <%= f.hidden_field :wheelchair, value: @ride.wheelchair ? "Yes" : "No" %>
-           <%= f.hidden_field :disabled, value: @ride.disabled ? "Yes" : "No" %>
-           <%= f.hidden_field :need_caregiver, value: @ride.need_caregiver ? "Yes" : "No" %>
-
-           <!-- Selected Passenger Overview -->
-           <div class="card mb-3">
-             <div class="card-header bg-success text-white py-2 d-flex justify-content-between align-items-center">
-               <h6 class="mb-0">Selected Passenger Overview</h6>
-               <!-- First Time Rider Badge -->
-                <div id="new_passenger_badge" style="display: none;">
-                  <span class="badge bg-warning text-dark" data-bs-toggle="tooltip" data-bs-placement="top" 
-                        title="This is a new passenger with no previous ride history">
-                    First Time Rider <i class="bi bi-exclamation-triangle"></i>
-                  </span>
+        <!-- Middle Column (Passenger Details) -->
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-info text-white">
+              <h5 class="mb-0 fw-bold">Passenger Details</h5>
+            </div>
+            <div class="card-body">
+              <div class="mb-3">
+                <%= f.label :passenger_name, "Passenger" %> <span class="text-danger">*</span>
+                <div class="input-group">
+                  <%= f.text_field :passenger_name, class: "form-control", required: true %>
+                  <%= link_to new_passenger_path(return_url: request.fullpath), class: "btn btn-success" do %>
+                    <i class="bi bi-person-plus"></i> Create
+                  <% end %>
                 </div>
-             </div>
+                <small class="form-text text-muted">Type to search existing passengers</small>
+              </div>
 
-             <div class="card-body">
-               <!-- Selected Passenger Name -->
-               <div class="mb-3">
-                 <label class="form-label">Passenger:</label>
-                 <input type="text" 
-                        class="form-control bg-light" 
-                        disabled
-                        id="name_display"
-                        value="No passenger selected">
-               </div>
+              <%= f.hidden_field :passenger_id, class: "form-control" %>
+              <%= f.hidden_field :wheelchair, value: @ride.wheelchair ? "Yes" : "No" %>
+              <%= f.hidden_field :disabled, value: @ride.disabled ? "Yes" : "No" %>
+              <%= f.hidden_field :need_caregiver, value: @ride.need_caregiver ? "Yes" : "No" %>
 
-               <div class="row">
-                 <div class="col-md-6">
-                   <div class="form-check mb-2">
-                     <input type="checkbox" 
-                            class="form-check-input bg-secondary opacity-50"
-                            disabled
-                            id="wheelchair_display">
-                     <label class="form-check-label" for="wheelchair_display">Requires Wheelchair</label>
-                   </div>
+              <!-- Selected Passenger Overview -->
+              <div class="card mb-3">
+                <div class="card-header bg-success text-white py-2 d-flex justify-content-between align-items-center">
+                  <h6 class="mb-0">Selected Passenger Overview</h6>
+                  <!-- First Time Rider Badge -->
+                  <div id="new_passenger_badge" style="display: none;">
+                    <span class="badge bg-warning text-dark" data-bs-toggle="tooltip" data-bs-placement="top" 
+                          title="This is a new passenger with no previous ride history">
+                      First Time Rider <i class="bi bi-exclamation-triangle"></i>
+                    </span>
+                  </div>
+                </div>
 
-                   <div class="form-check mb-2">
-                     <input type="checkbox" 
-                            class="form-check-input bg-secondary opacity-50"
-                            disabled
-                            id="disabled_display">
-                     <label class="form-check-label" for="disabled_display">Has Disability</label>
-                   </div>
-                 </div>
-
-                 <div class="col-md-6">
-                   <div class="form-check mb-2">
-                     <input type="checkbox" 
-                            class="form-check-input bg-secondary opacity-50"
-                            disabled
-                            id="need_caregiver_display">
-                     <label class="form-check-label" for="need_caregiver_display">Needs Caregiver</label>
-                   </div>
-                 </div>
-               </div>
-
-               <!-- Passenger Notes -->
-               <div class="mt-3">
-                 <label class="form-label">Accessibility Notes:</label>
-                 <textarea class="form-control bg-light" 
+                <div class="card-body">
+                  <!-- Selected Passenger Name -->
+                  <div class="mb-3">
+                    <label class="form-label">Passenger:</label>
+                    <input type="text" 
+                           class="form-control bg-light" 
                            disabled
-                           id="notes_display"
-                           rows="2">No notes available</textarea>
-               </div>
+                           id="name_display"
+                           value="No passenger selected">
+                  </div>
 
-               <!-- Passenger Phone -->
-               <div class="mt-3">
-                 <label class="form-label">Phone Number:</label>
-                 <input type="text" 
-                        class="form-control bg-light" 
-                        disabled
-                        id="phone_display"
-                        value="No phone available">
-               </div>
-             </div>
-           </div>
-           <!-- END: Accessibility Information -->
+                  <div class="row">
+                    <div class="col-md-6">
+                      <div class="form-check mb-2">
+                        <input type="checkbox" 
+                               class="form-check-input bg-secondary opacity-50"
+                               disabled
+                               id="wheelchair_display">
+                        <label class="form-check-label" for="wheelchair_display">Wheelchair</label>
+                      </div>
 
-           <!-- New Address Container with Justify Content Row -->
-           <div class="row g-4" id="address-grid">
-             <!-- Origin Address -->
-              <div class="col-md-5">
-                <h5 class="fw-bold text-success text-center">Origin</h5>
-                    <div class="mb-3">
-                        <label class="form-label" for="ride_start_address_attributes_name">Address Name</label>
-                        <input type="text"
-                            name="ride[addresses_attributes][][name]"
-                            class="form-control"
-                            id="ride_start_address_attributes_name"
-                            autocomplete="ride-name">
+                      <div class="form-check mb-2">
+                        <input type="checkbox" 
+                               class="form-check-input bg-secondary opacity-50"
+                               disabled
+                               id="disabled_display">
+                        <label class="form-check-label" for="disabled_display">Disability</label>
+                      </div>
                     </div>
 
-                    <div class="mb-3">
-                        <label class="form-label" for="ride_start_address_attributes_street">Street</label>
-                        <span class="text-danger">*</span>
-                        <input type="text"
-                            name="ride[addresses_attributes][][street]"
-                            class="form-control"
-                            id="ride_start_address_attributes_street"
-                            required
-                            autocomplete="ride-address">
+                    <div class="col-md-6">
+                      <div class="form-check mb-2">
+                        <input type="checkbox" 
+                               class="form-check-input bg-secondary opacity-50"
+                               disabled
+                               id="need_caregiver_display">
+                        <label class="form-check-label" for="need_caregiver_display">Caregiver</label>
+                      </div>
                     </div>
+                  </div>
 
-                    <div class="mb-3">
-                        <label class="form-label" for="ride_start_address_attributes_city">City</label>
-                        <span class="text-danger">*</span>
-                        <input type="text"
-                            name="ride[addresses_attributes][][city]"
-                            class="form-control"
-                            id="ride_start_address_attributes_city"
-                            required
-                            autocomplete="ride-city">
-                    </div>
+                  <!-- Passenger Notes -->
+                  <div class="mt-3">
+                    <label class="form-label">Accessibility Notes:</label>
+                    <textarea class="form-control bg-light" 
+                              disabled
+                              id="notes_display"
+                              rows="2">No notes available</textarea>
+                  </div>
 
-                    <div class="mb-3">
-                        <label class="form-label" for="ride_start_address_attributes_phone">Phone</label>
-                        <input type="text"
-                            name="ride[addresses_attributes][][phone]"
-                            class="form-control"
-                            id="ride_start_address_attributes_phone"
-                            autocomplete="ride-phone">
-                    </div>
+                  <!-- Passenger Phone -->
+                  <div class="mt-3">
+                    <label class="form-label">Phone Number:</label>
+                    <input type="text" 
+                           class="form-control bg-light" 
+                           disabled
+                           id="phone_display"
+                           value="No phone available">
+                  </div>
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
 
-             <!-- Spacer -->
-             <div class="col-md-1" id="col-space"></div>
+        <!-- Right Column (Stops Detail) -->
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-warning text-dark">
+              <h5 class="mb-0 fw-bold">Stops Detail</h5>
+            </div>
+            <div class="card-body" id="address-grid" data-last-index="1">
+              <!-- Origin Address -->
+              <div class="card mb-4">
+                <div class="card-header bg-secondary text-white">
+                  <h6 class="mb-0 fw-bold text-center">Origin</h6>
+                </div>
+                <div class="card-body">
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_name">Address Name</label>
+                    <input type="text"
+                           name="ride[addresses_attributes][][name]"
+                           class="form-control"
+                           id="ride_start_address_attributes_name"
+                           autocomplete="ride-name">
+                  </div>
 
-             <!-- Destination Address -->
-              <%= render partial: "stop_fields", locals: {index: 1, address: nil} %>                 
-             </div>
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_street">Street</label>
+                    <span class="text-danger">*</span>
+                    <input type="text"
+                           name="ride[addresses_attributes][][street]"
+                           class="form-control"
+                           id="ride_start_address_attributes_street"
+                           required
+                           autocomplete="ride-address">
+                  </div>
 
-             <div class="text-center mt-4">
-              <div class="mt-3">
-                <button type="button" class="btn btn-success mt-3" id="add-stop-button">Add Stop</button>
-                <button type="button" class="btn btn-danger mt-3" id="delete-stop-button">Delete Stop</button>
-             </div>
-           </div>
-           </div>
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_city">City</label>
+                    <span class="text-danger">*</span>
+                    <input type="text"
+                           name="ride[addresses_attributes][][city]"
+                           class="form-control"
+                           id="ride_start_address_attributes_city"
+                           required
+                           autocomplete="ride-city">
+                  </div>
 
+                  <div class="mb-3">
+                    <label class="form-label" for="ride_start_address_attributes_phone">Phone</label>
+                    <input type="text"
+                           name="ride[addresses_attributes][][phone]"
+                           class="form-control"
+                           id="ride_start_address_attributes_phone"
+                           autocomplete="ride-phone">
+                  </div>
+                </div>
+              </div>
 
-           <!-- Hidden Template for Additional Destination -->
-          <template id="destination-template">
-            <%= render partial: "stop_fields", locals: {index: "__INDEX__", address: nil} %>
-          </template>
-       </div>
+              <!-- Stops Container -->
+              <div id="stops-container">
+                <%= render partial: "stop_fields", locals: {index: 1, address: nil, drivers: @drivers} %>
+              </div>
 
+              <!-- Add/Delete Stop Buttons -->
+              <div class="text-center mt-4">
+                <button type="button" class="btn btn-success" id="add-stop-button">Add Stop</button>
+                <button type="button" class="btn btn-danger" id="delete-stop-button">Delete Stop</button>
+              </div>
 
-       <!-- Action Buttons -->
-       <div class="text-center mt-4">
-         <%= f.submit "Create Ride", class: "btn btn-success" %>
-         <%= link_to "Back to Rides", rides_path, class: "btn btn-secondary" %>
-       </div>
-     <% end %>
-   </div>
- </div>
+              <!-- Hidden Template for Additional Destination -->
+              <template id="destination-template">
+                <div class="col-md-12 mb-4">
+                  <div class="card">
+                    <div class="card-header bg-success text-white">
+                      <h6 class="mb-0 fw-bold text-center">Stop __INDEX__</h6>
+                    </div>
+                    <div class="card-body">
+                      <div class="row">
+                        <!-- Address Fields -->
+                        <div class="col-md-6">
+                          <h6 class="fw-bold text-muted mb-3">Address</h6>
+                                                     <div class="mb-3">
+                             <label class="form-label">Address Name</label>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][name]" 
+                                    class="form-control dest-autocomplete" 
+                                    id="ride_dest_address_attributes___INDEX___name"
+                                    autocomplete="ride-name">
+                           </div>
+                           <div class="mb-3">
+                             <label class="form-label">Street</label>
+                             <span class="text-danger">*</span>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][street]" 
+                                    class="form-control dest-autocomplete" 
+                                    id="ride_dest_address_attributes___INDEX___street"
+                                    required 
+                                    autocomplete="ride-address">
+                           </div>
+                           <div class="mb-3">
+                             <label class="form-label">City</label>
+                             <span class="text-danger">*</span>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][city]" 
+                                    class="form-control"
+                                    id="ride_dest_address_attributes___INDEX___city" 
+                                    required 
+                                    autocomplete="ride-city">
+                           </div>
+                           <div class="mb-3">
+                             <label class="form-label">Phone</label>
+                             <input type="text" 
+                                    name="ride[addresses_attributes][][phone]" 
+                                    class="form-control"
+                                    id="ride_dest_address_attributes___INDEX___phone" 
+                                    autocomplete="ride-phone">
+                           </div>
+                        </div>
+                        <!-- Driver and Van Fields -->
+                        <div class="col-md-6">
+                          <h6 class="fw-bold text-muted mb-3">Driver & Van</h6>
+                          <div class="mb-3">
+                            <label class="form-label">Driver</label>
+                            <span class="text-danger">*</span>
+                            <select name="ride[stops_attributes][][driver_id]" class="form-select driver-select" required>
+                              <option value="">Select a Driver</option>
+                            </select>
+                          </div>
+                          <div class="mb-3">
+                            <label class="form-label">Van</label>
+                            <input type="number" name="ride[stops_attributes][][van]" class="form-control">
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="text-center mt-4">
+        <%= f.submit "Create Ride", class: "btn btn-success" %>
+        <%= link_to "Back to Rides", rides_path, class: "btn btn-secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>
 

--- a/spec/controllers/drivers_controller_spec.rb
+++ b/spec/controllers/drivers_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe DriversController, type: :controller do
         # Create active drivers
         @active_driver1 = FactoryBot.create(:driver, name: "Active Driver A", active: true)
         @active_driver2 = FactoryBot.create(:driver, name: "Active Driver B", active: true)
-        
+
         # Create inactive drivers
         @inactive_driver1 = FactoryBot.create(:driver, name: "Inactive Driver A", active: false)
         @inactive_driver2 = FactoryBot.create(:driver, name: "Inactive Driver B", active: false)

--- a/spec/controllers/drivers_controller_spec.rb
+++ b/spec/controllers/drivers_controller_spec.rb
@@ -65,9 +65,109 @@ RSpec.describe DriversController, type: :controller do
       expect(response).to render_template(:index)
     end
 
+    context "active and inactive drivers separation" do
+      before do
+        # Create active drivers
+        @active_driver1 = FactoryBot.create(:driver, name: "Active Driver A", active: true)
+        @active_driver2 = FactoryBot.create(:driver, name: "Active Driver B", active: true)
+        
+        # Create inactive drivers
+        @inactive_driver1 = FactoryBot.create(:driver, name: "Inactive Driver A", active: false)
+        @inactive_driver2 = FactoryBot.create(:driver, name: "Inactive Driver B", active: false)
+      end
+
+      it "assigns active drivers to @active_drivers" do
+        get :index
+        expect(assigns(:active_drivers)).to match_array([@driver1, @driver2, @active_driver1, @active_driver2])
+      end
+
+      it "assigns inactive drivers to @inactive_drivers" do
+        get :index
+        expect(assigns(:inactive_drivers)).to match_array([@inactive_driver1, @inactive_driver2])
+      end
+
+      it "orders active drivers by name" do
+        get :index
+        active_drivers = assigns(:active_drivers)
+        expect(active_drivers.map(&:name)).to eq(active_drivers.map(&:name).sort)
+      end
+
+      it "orders inactive drivers by name" do
+        get :index
+        inactive_drivers = assigns(:inactive_drivers)
+        expect(inactive_drivers.map(&:name)).to eq(inactive_drivers.map(&:name).sort)
+      end
+
+      it "excludes inactive drivers from active drivers list" do
+        get :index
+        expect(assigns(:active_drivers)).not_to include(@inactive_driver1, @inactive_driver2)
+      end
+
+      it "excludes active drivers from inactive drivers list" do
+        get :index
+        expect(assigns(:inactive_drivers)).not_to include(@driver1, @driver2, @active_driver1, @active_driver2)
+      end
+
+      context "with only active drivers" do
+        before do
+          Driver.where(active: false).destroy_all
+        end
+
+        it "returns empty array for inactive drivers" do
+          get :index
+          expect(assigns(:inactive_drivers)).to be_empty
+        end
+
+        it "still returns active drivers" do
+          get :index
+          expect(assigns(:active_drivers)).not_to be_empty
+        end
+      end
+
+      context "with only inactive drivers" do
+        before do
+          Driver.where(active: true).destroy_all
+          @only_inactive = FactoryBot.create(:driver, name: "Only Inactive", active: false)
+        end
+
+        it "returns empty array for active drivers" do
+          get :index
+          expect(assigns(:active_drivers)).to be_empty
+        end
+
+        it "still returns inactive drivers" do
+          get :index
+          expect(assigns(:inactive_drivers)).to include(@only_inactive)
+        end
+      end
+
+      context "with mixed case names" do
+        before do
+          @mixed_case_active = FactoryBot.create(:driver, name: "zeta Active", active: true)
+          @mixed_case_inactive = FactoryBot.create(:driver, name: "Alpha Inactive", active: false)
+        end
+
+        it "orders active drivers alphabetically regardless of case" do
+          get :index
+          active_drivers = assigns(:active_drivers)
+          names = active_drivers.map(&:name)
+          expect(names).to eq(names.sort)
+        end
+
+        it "orders inactive drivers alphabetically regardless of case" do
+          get :index
+          inactive_drivers = assigns(:inactive_drivers)
+          names = inactive_drivers.map(&:name)
+          expect(names).to eq(names.sort)
+        end
+      end
+    end
+
     context "as driver with matching Driver record" do
       before do
         sign_in @driver1_user
+        # Create at least one inactive driver for testing assignment
+        @test_inactive_driver = FactoryBot.create(:driver, name: "Test Inactive Driver", active: false)
       end
 
       it "redirects to today_driver_path" do
@@ -78,6 +178,12 @@ RSpec.describe DriversController, type: :controller do
       it "renders the index template without redirecting" do
         get :index, params: { dont_jump: true }
         expect(response).to render_template(:index)
+      end
+
+      it "still assigns active and inactive drivers when not redirecting" do
+        get :index, params: { dont_jump: true }
+        expect(assigns(:active_drivers)).to include(@driver1, @driver2)
+        expect(assigns(:inactive_drivers)).to include(@test_inactive_driver)
       end
     end
   end

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -112,6 +112,37 @@ RSpec.describe RidesController, type: :controller do
         expect(response).to redirect_to(rides_path)
         expect(flash[:notice]).to eq("Ride was successfully created.")
       end
+
+      it "creates a new ride with per-stop driver and van assignment" do
+        attributes_with_stops = valid_attributes.merge(
+          addresses_attributes: [
+            { street: "123 Main St", city: "Oakland", state: "CA", zip: "94601" },
+            { street: "456 Second Ave", city: "Berkeley", state: "CA", zip: "94704" },
+            { street: "789 Third Ave", city: "San Francisco", state: "CA", zip: "94105" }
+          ],
+                  stops_attributes: [
+          { driver_id: @driver1.id, van: 1 },
+          { driver_id: @driver2.id, van: 2 }
+        ]
+        )
+
+        expect {
+          post :create, params: { ride: attributes_with_stops }
+        }.to change(Ride, :count).by(2)
+
+        created_rides = Ride.order(:created_at).last(2)
+        
+        # First ride should use first stop's driver and van
+        expect(created_rides[0].driver_id).to eq(@driver1.id)
+        expect(created_rides[0].van).to eq(1)
+        
+        # Second ride should use second stop's driver and van
+        expect(created_rides[1].driver_id).to eq(@driver2.id)
+        expect(created_rides[1].van).to eq(2)
+
+        expect(response).to redirect_to(rides_path)
+        expect(flash[:notice]).to eq("Ride was successfully created.")
+      end
     end
   end
 
@@ -200,6 +231,40 @@ RSpec.describe RidesController, type: :controller do
 
       expect(flash[:notice]).to eq("Ride was successfully updated.")
     end
+
+    it "updates a ride with per-stop driver and van assignment" do
+      # Create initial ride chain
+      ride1 = FactoryBot.create(:ride, passenger: @passenger1, driver: @driver1)
+      ride2 = FactoryBot.create(:ride, passenger: @passenger1, driver: @driver1)
+      ride1.update!(next_ride: ride2)
+      ride2.update!(previous_ride: ride1)
+
+      update_attrs = {
+        date: ride1.date,
+        passenger_id: ride1.passenger_id,
+        addresses_attributes: [
+          { street: "1 Start St", city: "A", state: "CA", zip: "90001" },
+          { street: "2 Middle St", city: "B", state: "CA", zip: "90002" },
+          { street: "3 End St", city: "C", state: "CA", zip: "90003" }
+        ],
+        stops_attributes: [
+          { driver_id: @driver1.id, van: 5 },
+          { driver_id: @driver2.id, van: 6 }
+        ]
+      }
+
+      put :update, params: { id: ride1.id, ride: update_attrs }
+      
+      # Should create 2 new rides (3 addresses = 2 ride segments)
+      updated_rides = Ride.order(:created_at).last(2)
+      
+      expect(updated_rides[0].driver_id).to eq(@driver1.id)
+      expect(updated_rides[0].van).to eq(5)
+      expect(updated_rides[1].driver_id).to eq(@driver2.id)
+      expect(updated_rides[1].van).to eq(6)
+
+      expect(flash[:notice]).to eq("Ride was successfully updated.")
+    end
   end
 
   describe "DELETE #destroy" do
@@ -250,6 +315,65 @@ RSpec.describe RidesController, type: :controller do
       expect {
         get :show, params: { id: -1 } # Non-existent ID
       }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe "parameter permissions" do
+    it "permits stops_attributes parameter" do
+      # This test ensures that stops_attributes with driver_id and van are permitted
+      valid_params = {
+        ride: {
+          date: Date.current,
+          driver_id: @driver1.id,
+          passenger_id: @passenger1.id,
+          addresses_attributes: [
+            { street: "123 Main", city: "Oakland", state: "CA", zip: "94601" },
+            { street: "456 Elm", city: "Berkeley", state: "CA", zip: "94704" }
+          ],
+          stops_attributes: [
+            { driver_id: @driver2.id, van: "5" }
+          ]
+        }
+      }
+
+      expect {
+        post :create, params: valid_params
+      }.to change(Ride, :count).by(1)
+
+      created_ride = Ride.last
+      expect(created_ride.driver_id).to eq(@driver2.id)
+      expect(created_ride.van).to eq(5)
+    end
+
+    it "ignores unpermitted parameters in stops_attributes" do
+      # This test ensures that any unpermitted parameters in stops_attributes are filtered out
+      valid_params = {
+        ride: {
+          date: Date.current,
+          driver_id: @driver1.id,
+          passenger_id: @passenger1.id,
+          addresses_attributes: [
+            { street: "123 Main", city: "Oakland", state: "CA", zip: "94601" },
+            { street: "456 Elm", city: "Berkeley", state: "CA", zip: "94704" }
+          ],
+          stops_attributes: [
+            { 
+              driver_id: @driver2.id, 
+              van: "5",
+              malicious_param: "should_be_filtered" # This should be ignored
+            }
+          ]
+        }
+      }
+
+      expect {
+        post :create, params: valid_params
+      }.to change(Ride, :count).by(1)
+
+      created_ride = Ride.last
+      expect(created_ride.driver_id).to eq(@driver2.id)
+      expect(created_ride.van).to eq(5)
+      # The malicious parameter should not affect the ride creation
     end
   end
 

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -131,11 +131,11 @@ RSpec.describe RidesController, type: :controller do
         }.to change(Ride, :count).by(2)
 
         created_rides = Ride.order(:created_at).last(2)
-        
+
         # First ride should use first stop's driver and van
         expect(created_rides[0].driver_id).to eq(@driver1.id)
         expect(created_rides[0].van).to eq(1)
-        
+
         # Second ride should use second stop's driver and van
         expect(created_rides[1].driver_id).to eq(@driver2.id)
         expect(created_rides[1].van).to eq(2)
@@ -254,10 +254,10 @@ RSpec.describe RidesController, type: :controller do
       }
 
       put :update, params: { id: ride1.id, ride: update_attrs }
-      
+
       # Should create 2 new rides (3 addresses = 2 ride segments)
       updated_rides = Ride.order(:created_at).last(2)
-      
+
       expect(updated_rides[0].driver_id).to eq(@driver1.id)
       expect(updated_rides[0].van).to eq(5)
       expect(updated_rides[1].driver_id).to eq(@driver2.id)
@@ -357,8 +357,8 @@ RSpec.describe RidesController, type: :controller do
             { street: "456 Elm", city: "Berkeley", state: "CA", zip: "94704" }
           ],
           stops_attributes: [
-            { 
-              driver_id: @driver2.id, 
+            {
+              driver_id: @driver2.id,
               van: "5",
               malicious_param: "should_be_filtered" # This should be ignored
             }

--- a/spec/factories/drivers.rb
+++ b/spec/factories/drivers.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
     factory :driver do
       sequence(:name) { |n| "Driver #{n.humanize.titleize}" }
-      sequence(:email)  { |n| "driver_#{n.humanize}son@gmail.com" }
-      sequence(:phone)  { |n| "(dri)-ver-#{n}#{n}#{n}#{n}" }
+      sequence(:email)  { |n| "driver#{n}@example.com" }
+      sequence(:phone)  { |n| "(555) 123-#{n.to_s.rjust(4, '0')}" }
       active { true }
     end
   end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -474,7 +474,6 @@ RSpec.describe Ride, type: :model do
 
         # Test from first ride in chain
         expect(rides[0].all_drivers_names).to eq("#{@driver1.name}, #{@driver2.name}")
-        
       end
 
       it "returns unique driver names when same driver appears multiple times" do
@@ -493,7 +492,6 @@ RSpec.describe Ride, type: :model do
 
         expect(rides[0].all_drivers_names).to eq(@driver1.name)
       end
-
     end
 
     describe "#all_vans_numbers" do
@@ -540,7 +538,7 @@ RSpec.describe Ride, type: :model do
       it "handles rides with nil vans gracefully" do
         ride1 = FactoryBot.create(:ride, van: 7)
         ride2 = FactoryBot.create(:ride, van: nil)
-        
+
         # Manually link the rides
         ride1.update!(next_ride: ride2)
 
@@ -550,7 +548,7 @@ RSpec.describe Ride, type: :model do
       it "returns empty string when all rides have nil vans" do
         ride1 = FactoryBot.create(:ride, van: nil)
         ride2 = FactoryBot.create(:ride, van: nil)
-        
+
         # Manually link the rides
         ride1.update!(next_ride: ride2)
 

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Ride, type: :model do
         addresses_attributes: [:name, :street, :city, :phone]
       )
 
-      attrs, addresses, stops_data = Ride.extract_attrs_from_params(input_params)
+      attrs, addresses, _ = Ride.extract_attrs_from_params(input_params)
 
       expect(attrs[:wheelchair]).to eq(true)
       expect(attrs[:disabled]).to eq(true)
@@ -229,7 +229,7 @@ RSpec.describe Ride, type: :model do
         addresses_attributes: [:name, :street, :city, :phone]
       )
 
-      attrs, addresses, stops_data = Ride.extract_attrs_from_params(input_params)
+      _, addresses, stops_data = Ride.extract_attrs_from_params(input_params)
 
       expect(stops_data).to eq([])
       expect(addresses.length).to eq(2)


### PR DESCRIPTION
Issues with new ride page:

Currently all rides created in multistop are assigned to a single driver and van, but one stop can be with driver1 and van1, and another can be with driver2 and van2. We need a selection of van and driver for each stop.

Currently there is no way to edit the name of an address, add in a way to edit the name after selecting it in stop


- [x] Make the page wider to incorporate more drivers per row
- [x] Start with inactive drivers hidden, with a button that reveals inactive drivers
- [x] We need a selection of van and driver for each stop
- [ ] add in a way to edit the name after selecting it in stops
- [ ] Make shifts corresponding to Unknown highlighted in red, these correlates to needing to find volunteers or drivers



CHANGES: 

![image](https://github.com/user-attachments/assets/844cc71a-f5c0-4380-863e-214a09e4cfaa)

![image](https://github.com/user-attachments/assets/53a3ae03-fbd6-4833-a122-04ef9da435af)

