### PR TITLE
fix shift feedback return bug

### DIFF
--- a/app/controllers/drivers_controller.rb
+++ b/app/controllers/drivers_controller.rb
@@ -63,8 +63,6 @@ class DriversController < ApplicationController
 
     # Clear return_to_driver parameter after redirect from drivers index page to /drivers/id/today?date=XXX page
     clear_return_to(:return_to_drivers_today_from_drivers_index)
-
-    clear_return_to(:return_to_drivers_today_from_drivers_index)
   end
 
   # NOTE: We deliberately disabled the `show` action.

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -85,7 +85,8 @@ class ShiftsController < ApplicationController
     if params[:commit_type] == "feedback"
       # Allow driver to submit feedback
       if @shift.update(shift_params)
-        redirect_to today_driver_path(id: @shift.driver_id)
+        redirect_to today_driver_path(id: @shift.driver_id, date: @shift.shift_date),
+          notice: "Shift feedback was successfully saved."
       else
         render :feedback, status: :unprocessable_entity
       end

--- a/spec/controllers/shifts_controller_spec.rb
+++ b/spec/controllers/shifts_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ShiftsController, type: :controller do
         sign_in @driver_user
       end
 
-      it "updates feedback fields and redirects to driver's today page" do
+      it "updates feedback fields and redirects to the driver's page for the specific shift date" do
         patch :update, params: {
           id: @shift.id,
           shift: {
@@ -133,14 +133,13 @@ RSpec.describe ShiftsController, type: :controller do
           },
           commit_type: "feedback"
         }
-
         @shift.reload
         expect(@shift.van).to eq(101)
         expect(@shift.pick_up_time).to eq("08:00")
         expect(@shift.drop_off_time).to eq("10:00")
         expect(@shift.odometer_pre).to eq("12345")
         expect(@shift.odometer_post).to eq("12400")
-        expect(response).to redirect_to(today_driver_path(id: @shift.driver_id))
+        expect(response).to redirect_to(today_driver_path(id: @shift.driver_id, date: @shift.shift_date))
       end
     end
 


### PR DESCRIPTION
The user is now redirected back to the specific date they were viewing before giving feedback..

<img width="850" alt="image" src="https://github.com/user-attachments/assets/3c5b6377-6e95-4dfa-99d3-a2400dc6670d" />

<img width="834" alt="image" src="https://github.com/user-attachments/assets/d850ae4f-1307-405b-a7f9-c1affcbd2a7f" />

<img width="959" alt="image" src="https://github.com/user-attachments/assets/f7593e39-0f63-445a-a185-0401e4e56e17" />

I also tried adding the Cucumber testing framework. However, this approach introduced unexpected complexities, resulting in modifications across 8 files and two persistent test failures that I was unable to diagnose. The failing Cucumber tests might be struggling to correctly parse or assert the URL parameters attached during the redirect.
