### PR TITLE
Write tests for #219

### DIFF
--- a/app/helpers/drivers_helper.rb
+++ b/app/helpers/drivers_helper.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module DriversHelper
+  def clickable_phone(phone)
+    return "N/A" if phone.blank?
+
+    sanitized_phone = phone.gsub(/[^\d+]/, "")
+    link_to(phone, "tel:#{sanitized_phone}")
+  end
+
   def clickable_address(address, label: nil, provider: :google)
     return "N/A" if address.blank?
 

--- a/app/views/drivers/today.html.erb
+++ b/app/views/drivers/today.html.erb
@@ -34,7 +34,7 @@
             <tr>
               <td><%= ride.passenger.name %></td>
               <td>
-                <%= link_to ride.passenger.phone, "tel:#{ride.passenger.phone.gsub(/[^\d+]/, '')}" %>
+                <%= clickable_phone(ride.passenger.phone) %>
               </td>
               <td>
                 <% 

--- a/spec/helpers/drivers_helper_spec.rb
+++ b/spec/helpers/drivers_helper_spec.rb
@@ -3,6 +3,20 @@
 require "rails_helper"
 
 RSpec.describe DriversHelper, type: :helper do
+  describe "#clickable_phone" do
+    it "returns N/A when phone is blank" do
+      expect(helper.clickable_phone(nil)).to eq("N/A")
+      expect(helper.clickable_phone("")).to eq("N/A")
+    end
+
+    it "returns a tel link with a sanitized phone number" do
+      html = helper.clickable_phone("(123) 456-7890")
+
+      expect(html).to include('href="tel:1234567890"')
+      expect(html).to include(">(123) 456-7890</a>")
+    end
+  end
+
   describe "#clickable_address" do
     it "returns N/A when address is blank" do
       expect(helper.clickable_address(nil)).to eq("N/A")
@@ -15,7 +29,7 @@ RSpec.describe DriversHelper, type: :helper do
       html = helper.clickable_address(address)
 
       expect(html).to include(
-        "href=\"https://www.google.com/maps/search/?api=1&query=2551%20Hearst%20Ave%2C%20Berkeley\""
+        "href=\"https://www.google.com/maps/search/?api=1&amp;query=2551%20Hearst%20Ave%2C%20Berkeley\""
       )
       expect(html).to include(">2551 Hearst Ave, Berkeley</a>")
       expect(html).to include('target="_blank"')
@@ -46,7 +60,7 @@ RSpec.describe DriversHelper, type: :helper do
       html = helper.clickable_address_with_options("2551 Hearst Ave, Berkeley")
 
       expect(html).to include(
-        "href=\"https://www.google.com/maps/search/?api=1&query=2551%20Hearst%20Ave%2C%20Berkeley\""
+        "href=\"https://www.google.com/maps/search/?api=1&amp;query=2551%20Hearst%20Ave%2C%20Berkeley\""
       )
       expect(html).to include(">2551 Hearst Ave, Berkeley</a>")
 


### PR DESCRIPTION
Implemented tests for #219 
- Added a `drivers_helper_spec.rb` that tests the linked address/phone number functionality
    - tests that address is correctly linked for both the Google Maps and Apple Maps links, and that the text displayed is correct
    - also tests that the phone number is correctly linked and sanitized
- Also made a small change to #219 itself. Moved the phone number sanitation/linking logic to drivers_helper to keep code cleaner.