### PR TITLE
Changed color of shift notes save button

### DIFF
--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -8,7 +8,7 @@
 
 <%= render "shift_rides" %>
 
-<div class="text-right mt-4">
+<div class="text-right mt-4 mb-3">
   <%= link_to "Add new ride", new_ride_path(date: @shift.shift_date, driver_id: @shift.driver), class: "btn btn-primary" %>
 </div>
 
@@ -17,7 +17,9 @@
   <%= form_with model: @shift do |form| %>
     <%= form.label :notes, "Notes about Shift/Timeline:" %>
     <%= form.text_area :notes, class: "form-control", value: @shift.notes, rows: 8 %> 
-    <%= form.submit "Save", class: "form-control"  %> 
+    <div class="text-center mt-2">
+      <%= form.submit "Save", class: "btn btn-success py-2" %>
+    </div>
   <% end %>
 </div>
 
@@ -30,4 +32,3 @@
         data: { turbo_confirm: 'Are you sure?' }
   %>
 </div>
-


### PR DESCRIPTION
Issue #227  
- Changed color of shift notes save button to be green and centered it so it is more obvious to dispatchers 
- Looked into possibility of autosave, but this is a bit more complicated to implement so we will confirm with the customer that this is something we want to prioritize for this/next iteration before moving forward 
- Did not observe bug where text disappears when user clicks out of the text box (works as intended)
- Minor change: added a bit of padding after "add new ride" button so there is some separation between shift and shift notes sections

<img width="1685" height="881" alt="image" src="https://github.com/user-attachments/assets/47e5e08f-b8eb-4cfb-ab9e-29c62bd24ce5" />
