### PR TITLE
Block Sad Paths

### DIFF
--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -40,6 +40,7 @@ class RidesController < ApplicationController
       ActiveRecord::Base.transaction do
         new_rides = Ride.build_linked_rides!(ride_attrs, addresses, stops_data)
 
+        new_rides.each(&:save!)
         @ride = new_rides.first
       end
 
@@ -92,8 +93,8 @@ class RidesController < ApplicationController
         @ride = new_rides.first
 
         if old_feedback_attrs
-          @ride&.feedback&.destroy!
-          @ride&.create_feedback!(old_feedback_attrs)
+          @ride.feedback&.destroy!
+          @ride.create_feedback!(old_feedback_attrs)
         end
       end
 

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -35,18 +35,26 @@ class RidesController < ApplicationController
 
   def create
     ride_attrs, addresses, stops_data = Ride.extract_attrs_from_params(ride_params)
-    result_rides, success = Ride.build_linked_rides(ride_attrs, addresses, stops_data)
 
-    if success
-      @ride = result_rides[0]
+    begin
+      ActiveRecord::Base.transaction do
+        new_rides = Ride.build_linked_rides!(ride_attrs, addresses, stops_data)
+
+        @ride = new_rides.first
+      end
+
       session[:return_to] ||= rides_path
       redirect_to session[:return_to], notice: "Ride was successfully created."
-    else
+
+    rescue ActiveRecord::RecordInvalid => e
       @ride = Ride.new(ride_attrs)
-      @ride.valid?
-      flash[:alert] = @ride.errors.full_messages.join
-      Rails.logger.info("Ride creation failed: #{@ride.errors.full_messages}")
-      render :new
+      flash.now[:alert] = "Creation failed: #{e.record.errors.full_messages.join('! ')}"
+      render :new, status: :unprocessable_entity
+
+    rescue => e
+      flash[:alert] = "A system error occurred: #{e.message}"
+      Rails.logger.error("System Error: #{e.backtrace.first(5)}")
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -70,31 +78,39 @@ class RidesController < ApplicationController
     @feedback = @ride.feedback
     old_feedback_attrs = @feedback.attributes.except("id", "created_at", "updated_at", "ride_id") if @feedback
 
+    all_rides = @ride.get_all_linked_rides
     ride_attrs, addresses, stops_data = Ride.extract_attrs_from_params(ride_params)
 
-    # Destroy old ride chain
-    all_rides = @ride.get_all_linked_rides
-    ActiveRecord::Base.transaction do
-      all_rides.reverse_each(&:destroy!)
-    end
+    begin
+      new_rides = Ride.build_linked_rides!(ride_attrs, addresses, stops_data)
 
-    # Rebuild new ride chain
-    result_rides, success = Ride.build_linked_rides(ride_attrs, addresses, stops_data)
+      ActiveRecord::Base.transaction do
+        # Destroy old ride chain
+        all_rides.reverse_each(&:destroy!)
 
-    if success
-      @ride = result_rides[0]
-      @ride.feedback.destroy if @ride.feedback && old_feedback_attrs
-      @ride.create_feedback!(old_feedback_attrs) if old_feedback_attrs
-      @ride.save!
+        new_rides.each(&:save!)
+        @ride = new_rides.first
+
+        if old_feedback_attrs
+          @ride&.feedback&.destroy!
+          @ride&.create_feedback!(old_feedback_attrs)
+        end
+      end
+
       flash[:notice] = "Ride was successfully updated."
       redirect_to edit_ride_path(@ride)
-    else
-      @all_rides = @ride.get_all_linked_rides
+
+    rescue ActiveRecord::RecordInvalid => e
+      @all_rides = all_rides
       @ride = Ride.new(ride_attrs)
-      @ride.valid?
-      flash[:alert] = @ride.errors.full_messages.join
-      Rails.logger.info("Ride update failed: #{@ride.errors.full_messages}")
-      render :edit
+      flash.now[:alert] = "Update failed: #{e.record.errors.full_messages.join('! ')}"
+      render :edit, status: :unprocessable_entity
+
+    rescue => e
+      flash[:alert] = "A system error occurred: #{e.message}"
+      Rails.logger.error("System Error: #{e.backtrace.first(5)}")
+      render :edit, status: :unprocessable_entity
+      raise ActiveRecord::Rollback
     end
   end
 

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -106,10 +106,8 @@ class RidesController < ApplicationController
       render :edit, status: :unprocessable_entity
 
     rescue => e
-      flash[:alert] = "A system error occurred: #{e.message}"
       Rails.logger.error("System Error: #{e.backtrace.first(5)}")
-      render :edit, status: :unprocessable_entity
-      raise ActiveRecord::Rollback
+      raise e
     end
   end
 

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -37,12 +37,10 @@ class RidesController < ApplicationController
     ride_attrs, addresses, stops_data = Ride.extract_attrs_from_params(ride_params)
 
     begin
-      ActiveRecord::Base.transaction do
-        new_rides = Ride.build_linked_rides!(ride_attrs, addresses, stops_data)
+      new_rides = Ride.build_linked_rides!(ride_attrs, addresses, stops_data)
 
-        new_rides.each(&:save!)
-        @ride = new_rides.first
-      end
+      new_rides.each(&:save!)
+      @ride = new_rides.first
 
       session[:return_to] ||= rides_path
       redirect_to session[:return_to], notice: "Ride was successfully created."

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -53,6 +53,10 @@ class Ride < ApplicationRecord
       prev_ride = ride
     end
 
+    if created_rides.empty?
+      raise ActiveRecord::RecordInvalid.new(Ride.new)
+    end
+
     created_rides
   end
 

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -25,43 +25,35 @@ class Ride < ApplicationRecord
     self.dest_address = Address.find_or_create_by!(normalized)
   end
 
-  def self.build_linked_rides(ride_attrs, addrs, stops_data = [])
+  def self.build_linked_rides!(ride_attrs, addrs, stops_data = [])
     created_rides = []
     prev_ride = nil
 
-    ActiveRecord::Base.transaction do
-      i = 0
-      while i < (addrs.length - 1)
-        origin = addrs[i]
-        destination = addrs[i + 1]
+    addrs&.each_cons(2)&.with_index do |(origin, destination), i|
+      # Create ride with base attributes
+      ride = Ride.new(ride_attrs)
 
-        # Create ride with base attributes
-        ride = Ride.new(ride_attrs)
-        ride.start_address_attributes = origin
-        ride.dest_address_attributes = destination
+      # These setters use find_or_create_by! and would raise ActiveRecord::RecordInvalid if necessary
+      ride.start_address_attributes = origin
+      ride.dest_address_attributes = destination
 
-        # Override driver and van if provided in stops_data
-        if stops_data.present? && stops_data[i].present?
-          stop_data = stops_data[i]
-          ride.driver_id = stop_data[:driver_id] if stop_data[:driver_id].present?
-          ride.van = stop_data[:van] if stop_data[:van].present?
-        end
-
-        if prev_ride
-          prev_ride.next_ride = ride
-          prev_ride.save!
-        end
-
-        ride.save!
-        created_rides << ride
-        prev_ride = ride
-        i += 1
+      # Override driver and van if provided in stops_data
+      if stops_data&.[](i)
+        stop_data = stops_data[i]
+        ride.driver_id = stop_data[:driver_id] if stop_data[:driver_id].present?
+        ride.van = stop_data[:van] if stop_data[:van].present?
       end
+
+      if prev_ride
+        prev_ride.next_ride = ride
+      end
+
+      ride.validate!
+      created_rides << ride
+      prev_ride = ride
     end
 
-    [created_rides, true]
-  rescue => e
-    [e, false]
+    created_rides
   end
 
   def get_all_linked_rides

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -124,17 +124,17 @@ RSpec.describe RidesController, type: :controller do
             { street: "456 Second Ave", city: "Berkeley", state: "CA", zip: "94704" },
             { street: "789 Third Ave", city: "San Francisco", state: "CA", zip: "94105" }
           ],
-                  stops_attributes: [
-          { driver_id: @driver1.id, van: 1 },
-          { driver_id: @driver2.id, van: 2 }
-        ]
+          stops_attributes: [
+            { driver_id: @driver1.id, van: 1 },
+            { driver_id: @driver2.id, van: 2 }
+          ]
         )
 
         expect {
           post :create, params: { ride: attributes_with_stops }
         }.to change(Ride, :count).by(2)
 
-        created_rides = Ride.order(:created_at).last(2)
+        created_rides = Ride.order(id: :desc).limit(2)
 
         # First ride should use first stop's driver and van
         expect(created_rides[0].driver_id).to eq(@driver1.id)
@@ -260,7 +260,7 @@ RSpec.describe RidesController, type: :controller do
       put :update, params: { id: ride1.id, ride: update_attrs }
 
       # Should create 2 new rides (3 addresses = 2 ride segments)
-      updated_rides = Ride.order(:created_at).last(2)
+      updated_rides = Ride.order(id: :desc).limit(2)
 
       expect(updated_rides[0].driver_id).to eq(@driver1.id)
       expect(updated_rides[0].van).to eq(5)

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe RidesController, type: :controller do
         expect(response).to render_template(:new)
       end
 
+      it "renders new when a generic system error occurs" do
+        allow(Ride).to receive(:build_linked_rides!).and_raise(StandardError, "Unknown Error!")
+        post :create, params: { ride: valid_attributes }
+        expect(response).to render_template(:new)
+      end
+
       it "creates a new ride with 3 addresses" do
         valid_attributes[:addresses_attributes] << {
           street: "789 Third Ave",
@@ -180,6 +186,12 @@ RSpec.describe RidesController, type: :controller do
 
     it "renders edit on failure" do
       put :update, params: { id: @ride1.id, ride: { driver_id: nil } }
+      expect(response).to render_template(:edit)
+    end
+
+    it "renders edit when a generic system error occurs" do
+      allow(Ride).to receive(:build_linked_rides!).and_raise(StandardError, "Unknown Error!")
+      post :update, params: { id: @ride1.id, ride: valid_attributes }
       expect(response).to render_template(:edit)
     end
 

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -184,15 +184,16 @@ RSpec.describe RidesController, type: :controller do
       expect(flash[:notice]).to eq("Ride was successfully updated.")
     end
 
-    it "renders edit on failure" do
+    it "renders edit on RecordInvalid failure" do
       put :update, params: { id: @ride1.id, ride: { driver_id: nil } }
       expect(response).to render_template(:edit)
     end
 
-    it "renders edit when a generic system error occurs" do
+    it "raises error when a generic system error occurs" do
       allow(Ride).to receive(:build_linked_rides!).and_raise(StandardError, "Unknown Error!")
-      post :update, params: { id: @ride1.id, ride: { driver_id: nil } }
-      expect(response).to render_template(:edit)
+      expect {
+        post :update, params: { id: @ride1.id, ride: { driver_id: nil } }
+      }.to raise_error
     end
 
     it "adds a new destination to the ride chain" do

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe RidesController, type: :controller do
 
     it "renders edit when a generic system error occurs" do
       allow(Ride).to receive(:build_linked_rides!).and_raise(StandardError, "Unknown Error!")
-      post :update, params: { id: @ride1.id, ride: valid_attributes }
+      post :update, params: { id: @ride1.id, ride: { driver_id: nil } }
       expect(response).to render_template(:edit)
     end
 

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -258,10 +258,10 @@ RSpec.describe Ride, type: :model do
 
       addrs = [a1, a2]
 
-      rides, success = Ride.build_linked_rides(ride_attrs, addrs)
+      rides = Ride.build_linked_rides!(ride_attrs, addrs)
 
+      expect { rides.each(&:save!) }.not_to raise_error
       expect(rides.length).to eq(1)
-      expect(success).to eq(true)
 
       expect(rides[0].start_address).to eq(a1)
       expect(rides[0].dest_address).to eq(a2)
@@ -278,10 +278,10 @@ RSpec.describe Ride, type: :model do
 
       addrs = [address0, address1, address2, address3]
 
-      rides, success  = Ride.build_linked_rides(ride_attrs, addrs)
+      rides = Ride.build_linked_rides!(ride_attrs, addrs)
 
+      expect { rides.each(&:save!) }.not_to raise_error
       expect(rides.length).to eq(3)
-      expect(success).to eq(true)
 
       expect(rides[0].start_address.address_no_zip).to eq("(Kaiser) 789 Broadway, San Francisco")
       expect(rides[0].dest_address.address_no_zip).to eq("(Kaiser) 1000 Dwight, Berkeley")
@@ -308,9 +308,9 @@ RSpec.describe Ride, type: :model do
 
       addrs = [shared_address, another_address, shared_address] # same address used again
 
-      rides, success = Ride.build_linked_rides(ride_attrs, addrs)
+      rides = Ride.build_linked_rides!(ride_attrs, addrs)
 
-      expect(success).to eq(true)
+      expect { rides.each(&:save!) }.not_to raise_error
       expect(rides.length).to eq(2)
 
       expect(rides[0].start_address_id).to eq(shared_address.id)
@@ -335,9 +335,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver2.id, van: 2 }
         ]
 
-        rides, success = Ride.build_linked_rides(ride_attrs, addrs, stops_data)
+        rides = Ride.build_linked_rides!(ride_attrs, addrs, stops_data)
 
-        expect(success).to eq(true)
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(2)
 
         # First ride: address1 -> address2 with driver1 and van 1
@@ -368,9 +368,9 @@ RSpec.describe Ride, type: :model do
           # Only one stop specified, second should use base attributes
         ]
 
-        rides, success = Ride.build_linked_rides(ride_attrs, addrs, stops_data)
+        rides = Ride.build_linked_rides!(ride_attrs, addrs, stops_data)
 
-        expect(success).to eq(true)
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(2)
 
         # First ride uses stops_data
@@ -391,10 +391,11 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver2.id } # van not specified
         ]
 
-        rides, success = Ride.build_linked_rides(ride_attrs, addrs, stops_data)
+        rides = Ride.build_linked_rides!(ride_attrs, addrs, stops_data)
 
-        expect(success).to eq(true)
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(1)
+
         expect(rides[0].driver_id).to eq(@driver2.id)
         expect(rides[0].van).to be_nil # not specified in stops_data
       end
@@ -408,10 +409,11 @@ RSpec.describe Ride, type: :model do
           { van: 3 } # driver_id not specified
         ]
 
-        rides, success = Ride.build_linked_rides(ride_attrs, addrs, stops_data)
+        rides = Ride.build_linked_rides!(ride_attrs, addrs, stops_data)
 
-        expect(success).to eq(true)
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(1)
+
         expect(rides[0].driver_id).to eq(ride_attrs[:driver_id]) # uses base
         expect(rides[0].van).to eq(3)
       end
@@ -427,9 +429,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver2.id, van: 7 }
         ]
 
-        rides, success = Ride.build_linked_rides(ride_attrs, addrs, stops_data)
+        rides = Ride.build_linked_rides!(ride_attrs, addrs, stops_data)
 
-        expect(success).to eq(true)
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(2)
 
         # First ride uses base attributes (empty stops_data entry ignored)
@@ -446,10 +448,11 @@ RSpec.describe Ride, type: :model do
 
         addrs = [address1, address2]
 
-        rides, success = Ride.build_linked_rides(ride_attrs, addrs) # no stops_data
+        rides = Ride.build_linked_rides!(ride_attrs, addrs) # no stops_data
 
-        expect(success).to eq(true)
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(1)
+
         expect(rides[0].driver_id).to eq(ride_attrs[:driver_id])
       end
     end
@@ -477,8 +480,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver2.id, van: 2 }
         ]
 
-        rides, success = Ride.build_linked_rides({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
-        expect(success).to eq(true)
+        rides = Ride.build_linked_rides!({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
+
+        expect { rides.each(&:save!) }.not_to raise_error
 
         # Test from first ride in chain
         expect(rides[0].all_drivers_names).to eq("#{@driver1.name}, #{@driver2.name}")
@@ -495,8 +499,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver1.id, van: 3 } # Same driver, different van
         ]
 
-        rides, success = Ride.build_linked_rides({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
-        expect(success).to eq(true)
+        rides = Ride.build_linked_rides!({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
+
+        expect { rides.each(&:save!) }.not_to raise_error
 
         expect(rides[0].all_drivers_names).to eq(@driver1.name)
       end
@@ -519,8 +524,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver2.id, van: 5 }
         ]
 
-        rides, success = Ride.build_linked_rides({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
-        expect(success).to eq(true)
+        rides = Ride.build_linked_rides!({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
+
+        expect { rides.each(&:save!) }.not_to raise_error
 
         # Test from first ride in chain
         expect(rides[0].all_vans_numbers).to eq("2, 5")
@@ -537,8 +543,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver2.id, van: 3 } # Same van, different driver
         ]
 
-        rides, success = Ride.build_linked_rides({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
-        expect(success).to eq(true)
+        rides = Ride.build_linked_rides!({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
+
+        expect { rides.each(&:save!) }.not_to raise_error
 
         expect(rides[0].all_vans_numbers).to eq("3")
       end
@@ -578,8 +585,9 @@ RSpec.describe Ride, type: :model do
           { driver_id: @driver3.id, van: 3 }
         ]
 
-        rides, success = Ride.build_linked_rides({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
-        expect(success).to eq(true)
+        rides = Ride.build_linked_rides!({ driver_id: @driver1.id, date: Date.current }, addrs, stops_data)
+
+        expect { rides.each(&:save!) }.not_to raise_error
         expect(rides.length).to eq(3)
 
         # Test from any ride in the chain


### PR DESCRIPTION
Mitigate Loss of Ride Data when Editing, where Addresses Fails Validation