### PR TITLE
296: Functionality Update! Make Inactive Drivers Unqueryable upon New/Edit/Duplicate

### DIFF
--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -2,6 +2,7 @@
 
 class RidesController < ApplicationController
   before_action :set_ride, only: %i[ show edit update destroy ]
+  before_action :set_active_drivers, only: %i[ new edit create update duplicate ]
   before_action -> { require_role("admin", "dispatcher") }, only: %i[ index new edit create update destroy duplicate ]
 
   # Have only rides without previous rides (HEAD rides) be displayed
@@ -24,9 +25,6 @@ class RidesController < ApplicationController
     @ride = Ride.new(params.permit(:date, :driver_id))
     @ride.build_start_address
     @ride.build_dest_address
-
-    # For driver dropdown list in creating / updating
-    @drivers = Driver.order(:name)
 
     # For autofilling first stop's driver
     @ride.driver_id = params[:driver_id]
@@ -61,7 +59,6 @@ class RidesController < ApplicationController
 
   def edit
     # For driver dropdown list in creating / updating
-    set_ride
     @all_rides = @ride.get_all_linked_rides
 
     # Load all passengers with their associations at once
@@ -72,9 +69,6 @@ class RidesController < ApplicationController
   end
 
   def update
-    set_ride
-    @drivers = Driver.order(:name)
-
     # Before destroying, copy feedback
     @feedback = @ride.feedback
     old_feedback_attrs = @feedback.attributes.except("id", "created_at", "updated_at", "ride_id") if @feedback
@@ -367,8 +361,15 @@ class RidesController < ApplicationController
     @ride = Ride.find(params[:id])
   end
 
+  def set_active_drivers
+    @drivers = Driver.active
+                     .or(Driver.where(id: @ride.present? ? @ride.get_all_linked_rides.pluck(:driver_id) : []))
+                     .order(:name)
+                     .distinct
+    gon.drivers = @drivers.map { |d| { id: d.id, name: d.name } }
+  end
+
   def load_gon_data
-    @drivers = Driver.order(:name)
     passengers_with_data = Passenger.includes(:address, :rides)
 
     gon.passengers = passengers_with_data.map { |p| {

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -3,4 +3,5 @@
 class Driver < ApplicationRecord
   has_many :rides, dependent: :nullify
   has_many :shifts, dependent: :destroy
+  scope :active, -> { where(active: true) }
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -59,10 +59,11 @@ class Ride < ApplicationRecord
   end
 
   def get_all_linked_rides
-    chain = [self]
+    # If 3 -> 2 -> 1, and this is 3, returns [3, 2, 1]
+    chain = []
     current = self
-    while current.next_ride
-      chain << current.next_ride
+    while current
+      chain << current
       current = current.next_ride
     end
     chain

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -108,13 +108,8 @@ RSpec.describe RidesController, type: :controller do
 
       get :new
 
-      # Check static HTML
       expect(assigns(:drivers)).to include(active_driver)
       expect(assigns(:drivers)).not_to include(inactive_driver)
-
-      # Check dynamic JS
-      expect(gon.drivers.map { |d| d[:id] }).to include(active_driver.id)
-      expect(gon.drivers.map { |d| d[:id] }).not_to include(inactive_driver.id)
     end
   end
 
@@ -133,11 +128,7 @@ RSpec.describe RidesController, type: :controller do
 
       get :edit, params: { id: head_ride.id }
 
-      # Check static HTML
       expect(assigns(:drivers)).to include(retired_driver)
-
-      # Check dynamic JS
-      expect(gon.drivers.map { |d| d[:id] }).to include(retired_driver.id)
     end
 
     it "excludes unrelated inactive drivers" do
@@ -515,7 +506,6 @@ RSpec.describe RidesController, type: :controller do
 
       # 4. Confirm they are NOT in the dropdown list for the new (duplicate) ride
       expect(assigns(:drivers)).not_to include(retired_driver)
-      expect(gon.drivers.map { |d| d[:id] }).not_to include(retired_driver.id)
     end
   end
 

--- a/spec/controllers/rides_controller_spec.rb
+++ b/spec/controllers/rides_controller_spec.rb
@@ -96,6 +96,58 @@ RSpec.describe RidesController, type: :controller do
     end
   end
 
+  describe "GET #new" do
+    it "returns a successful response" do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns only active drivers to @drivers and gon" do
+      inactive_driver = FactoryBot.create(:driver, active: false)
+      active_driver = FactoryBot.create(:driver, active: true)
+
+      get :new
+
+      # Check static HTML
+      expect(assigns(:drivers)).to include(active_driver)
+      expect(assigns(:drivers)).not_to include(inactive_driver)
+
+      # Check dynamic JS
+      expect(gon.drivers.map { |d| d[:id] }).to include(active_driver.id)
+      expect(gon.drivers.map { |d| d[:id] }).not_to include(inactive_driver.id)
+    end
+  end
+
+  describe "GET #edit" do
+    it "returns a successful response" do
+      get :edit, params: { id: @ride1.id }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "includes an inactive driver if they are assigned to the current ride chain" do
+      retired_driver = FactoryBot.create(:driver, active: false)
+
+      tail_ride = FactoryBot.create(:ride, passenger: @passenger1, driver: retired_driver)
+      head_ride = FactoryBot.create(:ride, passenger: @passenger1, driver: @driver1)
+      head_ride.update!(next_ride: tail_ride)
+
+      get :edit, params: { id: head_ride.id }
+
+      # Check static HTML
+      expect(assigns(:drivers)).to include(retired_driver)
+
+      # Check dynamic JS
+      expect(gon.drivers.map { |d| d[:id] }).to include(retired_driver.id)
+    end
+
+    it "excludes unrelated inactive drivers" do
+      unrelated_inactive = FactoryBot.create(:driver, active: false)
+      get :edit, params: { id: @ride1.id }
+
+      expect(assigns(:drivers)).not_to include(unrelated_inactive)
+    end
+  end
+
   describe "POST #create" do
     context "with valid attributes" do
       let(:valid_attributes) do
@@ -127,16 +179,6 @@ RSpec.describe RidesController, type: :controller do
             },
           ]
         }
-      end
-
-      it "GET #new" do
-        get :new
-        expect(response).to have_http_status(:success)
-      end
-
-      it "GET #edit" do
-        get :edit, params: { id: @ride1.id }
-        expect(response).to have_http_status(:success)
       end
 
       # Tests successful creation of a ride with multiple stops
@@ -458,6 +500,22 @@ RSpec.describe RidesController, type: :controller do
 
       duplicated_ride = assigns(:ride)
       expect(duplicated_ride.status).to eq("Pending")
+    end
+
+    it "blocks an inactive driver even if they were the original driver" do
+      # 1. Create a driver and a ride assigned to them
+      retired_driver = FactoryBot.create(:driver, active: true)
+      old_ride = FactoryBot.create(:ride, driver: retired_driver)
+
+      # 2. Driver retires
+      retired_driver.update(active: false)
+
+      # 3. Duplicate the old ride
+      get :duplicate, params: { id: old_ride.id }
+
+      # 4. Confirm they are NOT in the dropdown list for the new (duplicate) ride
+      expect(assigns(:drivers)).not_to include(retired_driver)
+      expect(gon.drivers.map { |d| d[:id] }).not_to include(retired_driver.id)
     end
   end
 


### PR DESCRIPTION
...unless:
- [x] `edit`: the ride already contains those `inactive` drivers. User can even add new stops with those `inactive` drivers.

More in issue #296.